### PR TITLE
Fix `ignored_layers` problem with different `deploy_backend`

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ cd AngelSlim && python setup.py install
 
 #### 1. 离线推理
 
-可以通过`transformers`加载量化模型，测试离线推理：
+如果需要通过`transformers`加载量化模型，请在量化模型配置中为`model`设置`deploy_backend: huggingface`，或者直接手动将量化产出模型路径下`config.json`配置中的`ignored_layers`字段改为`ignore`。
+
+测试`transformers`加载量化模型离线推理：
 
 ```shell
 python deploy/offline.py $MODEL_PATH
@@ -141,7 +143,7 @@ python deploy/offline.py $MODEL_PATH
 
 **vLLM**
 
-[vLLM](https://github.com/vllm-project/vllm) 服务启动脚本，建议版本`vllm>=0.8.5.post1`，部署MOE INT8量化模型需要`vllm>=0.9.0`。
+[vLLM](https://github.com/vllm-project/vllm) 服务启动脚本，建议版本`vllm>=0.8.5.post1`，部署MOE INT8量化模型需要`vllm>=0.9.2`。
 
 ```shell
 bash deploy/run_vllm.sh $MODEL_PATH

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ cd AngelSlim && python setup.py install
 
 #### 1. 离线推理
 
-如果需要通过`transformers`加载量化模型，请在量化模型配置中为`model`设置`deploy_backend: huggingface`，或者直接手动将量化产出模型路径下`config.json`配置中的`ignored_layers`字段改为`ignore`。
+如果需要通过`transformers`加载量化模型，请在量化模型配置的`global`中设置`deploy_backend: huggingface`，或者直接手动将量化产出模型路径下`config.json`配置中的`ignored_layers`字段改为`ignore`。
 
 测试`transformers`加载量化模型离线推理：
 

--- a/README_en.md
+++ b/README_en.md
@@ -125,7 +125,19 @@ For more details, please refer to the [Quick Start Documentation](https://angels
 
 ### Deployment and Testing
 
-#### 1. API Service Deployment
+### 1. Offline Inference
+
+If you need to load a quantized model via `transformers`, set the `deploy_backend: huggingface` in the `model` configuration before quantizing the model, or manually modify the `ignored_layers` field in the `config.json` file located in the quantized model output directory to `ignore`.
+
+To test offline inference with a quantized model loaded via `transformers`, run the following command:
+
+```shell
+python deploy/offline.py $MODEL_PATH
+```
+
+Where `MODEL_PATH` is the path to the quantized model output.
+
+#### 2. API Service Deployment
 
 After specifying the quantized model path `MODEL_PATH`, you can deploy an OpenAI-compatible API service using the following LLMs inference frameworks:
 
@@ -147,7 +159,7 @@ Use the following script to launch a [SGLang](https://github.com/sgl-project/sgl
 bash deploy/run_sglang.sh $MODEL_PATH
 ```
 
-#### 2. Service Invocation
+#### 3. Service Invocation
 
 Invoke requests via [OpenAI's API format](https://platform.openai.com/docs/api-reference/introduction):
 
@@ -155,7 +167,7 @@ Invoke requests via [OpenAI's API format](https://platform.openai.com/docs/api-r
 bash deploy/openai.sh $MODEL_PATH
 ```
 
-#### 3. Performance Evaluation
+#### 4. Performance Evaluation
 
 Evaluate the performance of quantized model using [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness), recommended version`lm-eval>=0.4.8`:
 

--- a/README_en.md
+++ b/README_en.md
@@ -127,7 +127,7 @@ For more details, please refer to the [Quick Start Documentation](https://angels
 
 ### 1. Offline Inference
 
-If you need to load a quantized model via `transformers`, set the `deploy_backend: huggingface` in the `model` configuration before quantizing the model, or manually modify the `ignored_layers` field in the `config.json` file located in the quantized model output directory to `ignore`.
+If you need to load a quantized model via `transformers`, please set the `deploy_backend: huggingface` in the `global` configuration before quantizing the model, or manually modify the `ignored_layers` field in the `config.json` file located in the quantized model output directory to `ignore`.
 
 To test offline inference with a quantized model loaded via `transformers`, run the following command:
 

--- a/angelslim/compressor/quant/core/config.py
+++ b/angelslim/compressor/quant/core/config.py
@@ -105,6 +105,7 @@ class QuantConfig:
             self.hidden_size = global_config.hidden_size
             self.model_arch_type = global_config.model_arch_type
             self.low_memory = config.quantization.low_memory
+            self.quant_analyse = config.quantization.quant_analyse
         elif "int4_awq" in self.quant_algo:
             self.act_observer = None
             self.weight_observer = None

--- a/angelslim/compressor/quant/core/save.py
+++ b/angelslim/compressor/quant/core/save.py
@@ -100,12 +100,14 @@ class PTQSaveVllmHF(PTQSaveBase):
         super().__init__(quant_model=quant_model)
 
     def save(self, save_path):
+        deploy_backend = self.quant_model.deploy_backend
+        ignore_field = "ignored_layers" if deploy_backend == "vllm" else "ignore"
         w_quant_algo = self.quant_model.quant_config.quant_algo_info["w"]
         a_quant_algo = self.quant_model.quant_config.quant_algo_info["a"]
-        ignore_layers = self.quant_model.skip_layer_names()
+        ignored_layers = self.quant_model.skip_layer_names()
         trtllm_config = {
             "quantization": {
-                "exclude_modules": ignore_layers,
+                "exclude_modules": ignored_layers,
                 "kv_cache_quant_algo": None,
             }
         }
@@ -157,7 +159,7 @@ class PTQSaveVllmHF(PTQSaveBase):
                 },
                 "kv_cache_scheme": None,
                 "format": quant_format,
-                "ignore": ignore_layers,
+                ignore_field: ignored_layers,
                 "quantization_status": "compressed",
                 "quant_method": "compressed-tensors",
             }

--- a/angelslim/models/base_model.py
+++ b/angelslim/models/base_model.py
@@ -48,7 +48,7 @@ class BaseModel(metaclass=ABCMeta):
     ):
         assert modal_type in ["LLM", "AIGC", "TTS"]
         self.modal_type = modal_type
-        assert deploy_backend in ["vllm"]
+        assert deploy_backend in ["vllm", "huggingface"]
         self.deploy_backend = deploy_backend
         self.model = None
         assert (
@@ -100,7 +100,7 @@ class BaseModel(metaclass=ABCMeta):
             act_scale = self.act_scales_dict[name]
         if name in self.weight_scales_dict:
             weight_scale = self.weight_scales_dict[name]
-        if self.deploy_backend == "vllm":
+        if self.deploy_backend in ["vllm", "huggingface"]:
             q_linear = QDQModule(
                 quant_algo=self.quant_config.quant_algo,
                 weight=sub_layer.weight,

--- a/angelslim/models/llm/deepseek.py
+++ b/angelslim/models/llm/deepseek.py
@@ -71,7 +71,7 @@ class DeepSeek(BaseModel):
         return observer_layers_dict
 
     def get_save_func(self):
-        if self.deploy_backend == "vllm":
+        if self.deploy_backend in ["vllm", "huggingface"]:
             return PTQSaveVllmHF
         else:
             raise NotImplementedError(

--- a/angelslim/models/llm/hunyuan_dense.py
+++ b/angelslim/models/llm/hunyuan_dense.py
@@ -63,7 +63,7 @@ class HunyuanDense(BaseModel):
         return observer_layers_dict
 
     def get_save_func(self):
-        if self.deploy_backend == "vllm":
+        if self.deploy_backend in ["vllm", "huggingface"]:
             return PTQSaveVllmHF
         else:
             raise NotImplementedError(

--- a/angelslim/models/llm/hunyuan_moe.py
+++ b/angelslim/models/llm/hunyuan_moe.py
@@ -86,7 +86,7 @@ class HunyuanMoE(BaseModel):
         return parent_dict
 
     def get_save_func(self):
-        if self.deploy_backend == "vllm":
+        if self.deploy_backend in ["vllm", "huggingface"]:
             return PTQSaveVllmHF
         else:
             raise NotImplementedError(

--- a/angelslim/models/llm/llama.py
+++ b/angelslim/models/llm/llama.py
@@ -60,7 +60,7 @@ class Llama(BaseModel):
         return observer_layers_dict
 
     def get_save_func(self):
-        if self.deploy_backend == "vllm":
+        if self.deploy_backend in ["vllm", "huggingface"]:
             return PTQSaveVllmHF
         else:
             raise NotImplementedError(

--- a/angelslim/models/llm/qwen.py
+++ b/angelslim/models/llm/qwen.py
@@ -89,7 +89,7 @@ class Qwen(BaseModel):
         return parent_dict
 
     def get_save_func(self):
-        if self.deploy_backend == "vllm":
+        if self.deploy_backend in ["vllm", "huggingface"]:
             return PTQSaveVllmHF
         else:
             raise NotImplementedError(

--- a/angelslim/utils/__init__.py
+++ b/angelslim/utils/__init__.py
@@ -19,6 +19,7 @@ from .utils import find_parent_layer_and_sub_name  # noqa: F401
 from .utils import get_best_device  # noqa: F401
 from .utils import get_op_by_name  # noqa: F401
 from .utils import get_op_name  # noqa: F401
+from .utils import get_package_info  # noqa: F401
 from .utils import get_tensor_item  # noqa: F401
 from .utils import get_yaml_prefix_simple  # noqa: F401
 from .utils import print_info  # noqa: F401

--- a/angelslim/utils/config_parser.py
+++ b/angelslim/utils/config_parser.py
@@ -22,11 +22,22 @@ from .utils import get_hf_config
 
 @dataclass
 class GlobalConfig:
+    """
+    Global configuration for LLM compression.
+    Attributes:
+        save_path: Directory to save compressed models
+        max_seq_length: Maximum sequence length for calibration data
+        hidden_size: Hidden size of the model
+        model_arch_type: Model architecture type
+        deploy_backend: Backend for deployment (e.g., "vllm", "huggingface")
+    """
+
     save_path: str = field(default="./output")
     # Shared max_seq_length configuration
     max_seq_length: int = field(default=2048)
     hidden_size: int = field(default=2048)
     model_arch_type: str = field(default=None)
+    deploy_backend: str = field(default="vllm")
 
     def set_max_seq_length(self, value: int):
         self.max_seq_length = value
@@ -55,7 +66,6 @@ class ModelConfig:
         trust_remote_code: Trust remote code for HuggingFace
         torch_dtype: PyTorch dtype for loading (e.g., "bfloat16")
         device_map: Strategy for device placement (e.g., "auto", "cpu", "cuda")
-        deploy_backend: Backend for deployment (e.g., "vllm", "huggingface")
     """
 
     name: str
@@ -65,7 +75,6 @@ class ModelConfig:
     device_map: str = field(default="auto")
     low_cpu_mem_usage: bool = field(default=True)
     use_cache: bool = field(default=False)
-    deploy_backend: str = field(default="vllm")
 
 
 @dataclass

--- a/angelslim/utils/config_parser.py
+++ b/angelslim/utils/config_parser.py
@@ -54,7 +54,8 @@ class ModelConfig:
         model_path: Path to model weights/directory
         trust_remote_code: Trust remote code for HuggingFace
         torch_dtype: PyTorch dtype for loading (e.g., "bfloat16")
-        device_map: Strategy for device placement
+        device_map: Strategy for device placement (e.g., "auto", "cpu", "cuda")
+        deploy_backend: Backend for deployment (e.g., "vllm", "huggingface")
     """
 
     name: str
@@ -64,6 +65,7 @@ class ModelConfig:
     device_map: str = field(default="auto")
     low_cpu_mem_usage: bool = field(default=True)
     use_cache: bool = field(default=False)
+    deploy_backend: str = field(default="vllm")
 
 
 @dataclass

--- a/docs/source/deployment/deploy.md
+++ b/docs/source/deployment/deploy.md
@@ -37,7 +37,7 @@
 },
 ```
 
-如果需要通过`transformers`加载量化模型，请在量化模型配置中为`model`设置`deploy_backend: huggingface`，或者直接手动将量化产出模型路径下`config.json`配置中的`ignored_layers`字段改为`ignore`。
+如果需要通过`transformers`加载量化模型，请在量化模型配置的`global`中设置`deploy_backend: huggingface`，或者直接手动将量化产出模型路径下`config.json`配置中的`ignored_layers`字段改为`ignore`。
 
 测试transformers加载量化模型：
 

--- a/docs/source/deployment/deploy.md
+++ b/docs/source/deployment/deploy.md
@@ -28,7 +28,7 @@
     }
   },
   "format": "naive-quantized",
-  "ignore": [
+  "ignored_layers": [
     "lm_head",
     "model.embed_tokens"
   ],
@@ -37,7 +37,10 @@
 },
 ```
 
-可以通过transformers加载量化模型，测试离线推理：
+如果需要通过`transformers`加载量化模型，请在量化模型配置中为`model`设置`deploy_backend: huggingface`，或者直接手动将量化产出模型路径下`config.json`配置中的`ignored_layers`字段改为`ignore`。
+
+测试transformers加载量化模型：
+
 ```python
 from transformers import AutoModelForCausalLM, AutoTokenizer
 model = AutoModelForCausalLM.from_pretrained(
@@ -53,7 +56,6 @@ outputs = model.generate(**inputs)
 print(tokenizer.decode(outputs[0]))
 ```
 
-
 ## 2. 启动服务
 
 ### vLLM
@@ -68,7 +70,7 @@ print(tokenizer.decode(outputs[0]))
 
 - 启动兼容OpenAI格式的API服务
     
-    以下指令将启动兼容OpenAI API格式的服务，默认在 http://0.0.0.0:8080 地址进行访问：
+    以下指令将启动兼容OpenAI API格式的服务，默认在 http://localhost:8080 地址进行访问：
 
     ```shell
     python3 -m vllm.entrypoints.openai.api_server \
@@ -119,8 +121,13 @@ print(tokenizer.decode(outputs[0]))
   fi
   ```
 
-  在两节点都执行上述指令后，可以在主节点的 http://0.0.0.0:8080 访问服务。
+  在两节点都执行上述指令后，可以在主节点的 http://localhost:8080 访问服务。
   
+:::{note}
+- 如果在部署Qwen3 MOE量化模型时遇到报错 `RuntimeError: CUDA error: no kernel image is available for execution on the device`，尝试将 `vllm` 版本升级到 `0.9.2`
+- 相关参考Issue：[链接](https://github.com/vllm-project/vllm/issues/19690)
+:::
+
 
 ### SGLang
 
@@ -132,7 +139,7 @@ print(tokenizer.decode(outputs[0]))
 
 - 启动兼容OpenAI格式的API服务
     
-    下面的指令会在本地 http://0.0.0.0:8080 启动服务：
+    下面的指令会在本地 http://localhost:8080 启动服务：
 
     ```shell
     python -m sglang.launch_server \

--- a/tools/run.py
+++ b/tools/run.py
@@ -73,7 +73,7 @@ def run(config):
         trust_remote_code=model_config.trust_remote_code,
         low_cpu_mem_usage=model_config.low_cpu_mem_usage,
         use_cache=model_config.use_cache,
-        deploy_backend=model_config.deploy_backend,
+        deploy_backend=global_config.deploy_backend,
     )
 
     # Step 4: Prepare data (optional custom dataloader)

--- a/tools/run.py
+++ b/tools/run.py
@@ -73,6 +73,7 @@ def run(config):
         trust_remote_code=model_config.trust_remote_code,
         low_cpu_mem_usage=model_config.low_cpu_mem_usage,
         use_cache=model_config.use_cache,
+        deploy_backend=model_config.deploy_backend,
     )
 
     # Step 4: Prepare data (optional custom dataloader)
@@ -98,7 +99,7 @@ def run(config):
     slim_engine.run()
 
     # Step 7: Save compressed model
-    slim_engine.save(global_config.save_path)
+    slim_engine.save(global_config.save_path, config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Use `ignored_layers` for `vllm` and `ignore` for `huggingface` in the quantized model configurations.
* Update the documentation to add the usage of the `global_config.deploy_backend` field.
* Save the runtime configuration and environment `debug_info` in the output folder.
    <img width="1039" height="1042" alt="image" src="https://github.com/user-attachments/assets/1f0169e9-32f7-44be-b7e1-8361d7831827" />

