### PR TITLE
fix compression name typo (#40)

### DIFF
--- a/configs/qwen3/fp8_static/qwen3-14b_fp8_static.yaml
+++ b/configs/qwen3/fp8_static/qwen3-14b_fp8_static.yaml
@@ -14,7 +14,7 @@ model:
 
 # Compression configuration
 compression:
-  name: quantization
+  name: PTQ
   quantization:
     name: fp8_static
     bits: 8

--- a/configs/qwq/fp8_dynamic/qwq-32b_fp8_dynamic.yaml
+++ b/configs/qwq/fp8_dynamic/qwq-32b_fp8_dynamic.yaml
@@ -11,7 +11,7 @@ model:
 
 # Compression configuration
 compression:
-  name: quantization
+  name: PTQ
   quantization:
     name: fp8_dynamic     # Supported: fp8_static, fp8_dynamic, int4_awq, int4_gptq
     bits: 8                # Quantization bits (4/8)

--- a/configs/qwq/fp8_static/qwq-32b_fp8_static.yaml
+++ b/configs/qwq/fp8_static/qwq-32b_fp8_static.yaml
@@ -11,7 +11,7 @@ model:
 
 # Compression configuration
 compression:
-  name: quantization
+  name: PTQ
   quantization:
     name: fp8_static     # Supported: fp8_static, fp8_dynamic, int4_awq, int4_gptq
     bits: 8                # Quantization bits (4/8)

--- a/docs/source/design/architecture.md
+++ b/docs/source/design/architecture.md
@@ -17,7 +17,7 @@ model:
   ...
 
 compression:
-  name: quantization
+  name: PTQ
   quantization:
     name: fp8_static
   ...

--- a/docs/source/features/quantization/fp8.md
+++ b/docs/source/features/quantization/fp8.md
@@ -21,7 +21,7 @@ python3 tools/run.py -c configs/qwen2_5/fp8_dynamic/qwen2_5-7b_instruct_fp8_dyna
 
 ```yaml
 compression:
-  name: quantization
+  name: PTQ
   quantization:
     name: fp8_dynamic
     bits: 8

--- a/docs/source/features/quantization/int8.md
+++ b/docs/source/features/quantization/int8.md
@@ -21,7 +21,7 @@ python3 tools/run.py -c configs/qwen3/int8_dynamic/qwen3-0_6b_int8_dynamic.yaml
 
 ```yaml
 compression:
-  name: quantization
+  name: PTQ
   quantization:
     name: int8_dynamic     # Supported: fp8_static, fp8_dynamic, int4_awq, int4_gptq, int8_dynamic
     bits: 8                # Quantization bits


### PR DESCRIPTION
fix `ValueError: Unsupported compression method: quantization. Supported methods: ['PTQ', 'QAT', 'Cache', 'speculative_decoding']` bug