### PR TITLE
fix w_group_size KeyError in DeepSeek per-tensor quant

### DIFF
--- a/angelslim/models/llm/deepseek.py
+++ b/angelslim/models/llm/deepseek.py
@@ -163,7 +163,7 @@ class DeepSeek(BaseLLMModel):
             quant_algo=self.quant_config.quant_algo,
             weight=weight,
             weight_scale=weight_scale,
-            group_size=self.quant_config.quant_algo_info["w_group_size"],
+            group_size=self.quant_config.quant_algo_info.get("w_group_size", 128),
             bias=layer.bias,
             input_scale=act_scale,
         )


### PR DESCRIPTION
解决执行 python3 tools/run.py -c configs/deepseek_r1/fp8_static/deepseek_r1_fp8_static_low_memmory.yaml 时的报错问题。

报错位置：
`File "AngelSlim/angelslim/models/llm/deepseek.py", line 166, in get_qdq_module`