### PR TITLE
fix vllm benchmark multi processing problem

### DIFF
--- a/angelslim/compressor/speculative/benchmark/vllm/generate_baseline_answer.py
+++ b/angelslim/compressor/speculative/benchmark/vllm/generate_baseline_answer.py
@@ -14,13 +14,13 @@
 
 import argparse
 import json
+import multiprocessing as mp
 import os
 import random
 import time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import numpy as np
-import ray
 import shortuuid
 import torch
 from fastchat.llm_judge.common import load_questions
@@ -187,16 +187,20 @@ def get_model_answers(
     num_choices: int,
     temperature: float,
     args: argparse.Namespace,
+    lock: Optional[mp.Lock] = None,
+    device_list: Optional[List] = None,
 ) -> None:
     """Generate answers for a batch of questions."""
     config = EvaluationConfig(args)
+    if device_list:
+        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, device_list))
+
     llm = initialize_model(config, args)
     tokenizer = AutoTokenizer.from_pretrained(config.base_model_path)
 
     if questions:
         warmup_model(llm, tokenizer, questions[0], temperature, config.max_tokens)
 
-    os.makedirs(os.path.dirname(answer_file), exist_ok=True)
     print(
         f"Generating {len(questions)} answers to {answer_file}, "
         f"batch_size={config.batch_size}"
@@ -294,45 +298,37 @@ def get_model_answers(
                     }
                 )
 
-            with open(os.path.expanduser(answer_file), "a") as fout:
-                ans_json = {
-                    "question_id": question["question_id"],
-                    "answer_id": shortuuid.uuid(),
-                    "model_id": model_id,
-                    "choices": choices,
-                    "tstamp": time.time(),
-                }
-                fout.write(json.dumps(ans_json) + "\n")
+            ans_json = {
+                "question_id": question["question_id"],
+                "answer_id": shortuuid.uuid(),
+                "model_id": model_id,
+                "choices": choices,
+                "tstamp": time.time(),
+            }
+
+            if lock:
+                with lock:
+                    with open(os.path.expanduser(answer_file), "a") as fout:
+                        fout.write(json.dumps(ans_json) + "\n")
+            else:
+                with open(os.path.expanduser(answer_file), "a") as fout:
+                    fout.write(json.dumps(ans_json) + "\n")
 
 
 def run_evaluation(config: EvaluationConfig, args: argparse.Namespace) -> None:
-    """Run the evaluation with optional distributed processing"""
+    """Run the evaluation. Standalone execution is single-process."""
     questions = load_questions(
         config.question_file, args.question_begin, args.question_end
     )
 
-    use_ray = args.num_gpus_total // args.num_gpus_per_model > 1
-    get_answers_func = (
-        ray.remote(num_gpus=args.num_gpus_per_model)(get_model_answers).remote
-        if use_ray
-        else get_model_answers
+    get_model_answers(
+        config.model_id,
+        questions,
+        config.answer_file,
+        config.num_choices,
+        config.temperature,
+        args,
     )
-
-    chunk_size = len(questions) // (args.num_gpus_total // args.num_gpus_per_model)
-    ans_handles = [
-        get_answers_func(
-            config.model_id,
-            questions[i : i + chunk_size],
-            config.answer_file,
-            config.num_choices,
-            config.temperature,
-            args,
-        )
-        for i in range(0, len(questions), chunk_size)
-    ]
-
-    if use_ray:
-        ray.get(ans_handles)
 
 
 def reorg_answer_file(answer_file: str) -> None:
@@ -388,9 +384,6 @@ def main() -> None:
     """Main execution function"""
     args = parse_args()
     setup_seed(args.seed)
-
-    if args.num_gpus_total // args.num_gpus_per_model > 1:
-        ray.init()
 
     config = EvaluationConfig(args)
     os.makedirs(os.path.dirname(config.answer_file), exist_ok=True)


### PR DESCRIPTION
This pull request removes Ray-based distributed processing from the vLLM benchmarking code and replaces it with Python's built-in multiprocessing module. The update affects both the Eagle and baseline answer generation workflows, improving compatibility and simplifying the codebase. The multiprocessing approach now handles parallel execution across multiple GPUs, and file-writing is made safe for concurrent processes. Additional minor improvements include better error handling and device assignment.

Key changes by theme:

**Migration from Ray to Multiprocessing:**

* All Ray dependencies and logic have been removed from `benchmark_engine.py`, `generate_baseline_answer.py`, and `generate_eagle_answer.py`. Instead, Python's `multiprocessing` is used for multi-GPU parallelism, including process spawning, locking, and shared result lists. [[1]](diffhunk://#diff-f3509951d7aae94d4e4b57c9314b1dd008d24d9504b2dc2c93d4ac46821ca43cR17-L22) [[2]](diffhunk://#diff-10f869e9368ab38d604823cb9511c74f424e763ddb08877f83a53e797d6aff03R17-L23) [[3]](diffhunk://#diff-6c4434394f15ce867abda8b788a1966cef0111024c7817f9534d3986a5e84008R17-L23)
* The benchmark runner now splits work across processes, assigns GPUs using `CUDA_VISIBLE_DEVICES`, and synchronizes output file writes with a multiprocessing lock. [[1]](diffhunk://#diff-f3509951d7aae94d4e4b57c9314b1dd008d24d9504b2dc2c93d4ac46821ca43cL117-R122) [[2]](diffhunk://#diff-f3509951d7aae94d4e4b57c9314b1dd008d24d9504b2dc2c93d4ac46821ca43cL137-R201) [[3]](diffhunk://#diff-f3509951d7aae94d4e4b57c9314b1dd008d24d9504b2dc2c93d4ac46821ca43cR211-L231) [[4]](diffhunk://#diff-10f869e9368ab38d604823cb9511c74f424e763ddb08877f83a53e797d6aff03R190-L199) [[5]](diffhunk://#diff-10f869e9368ab38d604823cb9511c74f424e763ddb08877f83a53e797d6aff03L297-L335) [[6]](diffhunk://#diff-6c4434394f15ce867abda8b788a1966cef0111024c7817f9534d3986a5e84008R237-L246) [[7]](diffhunk://#diff-6c4434394f15ce867abda8b788a1966cef0111024c7817f9534d3986a5e84008L342-R384)

**File Handling and Concurrency:**

* Output directories for answer files are created if they do not exist, ensuring safe file output in both single and multi-process scenarios. [[1]](diffhunk://#diff-f3509951d7aae94d4e4b57c9314b1dd008d24d9504b2dc2c93d4ac46821ca43cL137-R201) [[2]](diffhunk://#diff-f3509951d7aae94d4e4b57c9314b1dd008d24d9504b2dc2c93d4ac46821ca43cR211-L231)
* File writes are protected by a lock during multiprocessing to avoid race conditions, and results are aggregated via a shared list where needed. [[1]](diffhunk://#diff-10f869e9368ab38d604823cb9511c74f424e763ddb08877f83a53e797d6aff03L297-L335) [[2]](diffhunk://#diff-6c4434394f15ce867abda8b788a1966cef0111024c7817f9534d3986a5e84008L342-R384)

**Error Handling and Logging:**

* Improved error handling in `_reorg_answer_file` to catch and log invalid JSON lines instead of crashing.
* Minor logging improvements, such as correcting the environment variable name in device assignment logs.

**API and Function Signature Updates:**

* Added optional `lock`, `results_list`, and `device_list` parameters to answer generation functions to support multiprocessing and GPU assignment. [[1]](diffhunk://#diff-10f869e9368ab38d604823cb9511c74f424e763ddb08877f83a53e797d6aff03R190-L199) [[2]](diffhunk://#diff-6c4434394f15ce867abda8b788a1966cef0111024c7817f9534d3986a5e84008R237-L246)

**Code Simplification:**

* Standalone execution paths are now always single-process and simplified, as Ray-based distributed execution is no longer supported. [[1]](diffhunk://#diff-10f869e9368ab38d604823cb9511c74f424e763ddb08877f83a53e797d6aff03L297-L335) [[2]](diffhunk://#diff-6c4434394f15ce867abda8b788a1966cef0111024c7817f9534d3986a5e84008L342-R384) [[3]](diffhunk://#diff-10f869e9368ab38d604823cb9511c74f424e763ddb08877f83a53e797d6aff03L392-L394) [[4]](diffhunk://#diff-6c4434394f15ce867abda8b788a1966cef0111024c7817f9534d3986a5e84008L450-L452)

These changes collectively modernize the benchmarking workflow to use standard Python multiprocessing, making the codebase easier to maintain and run in diverse environments.