### PR TITLE
add attn_implementation in model config;fix deepseekv3.1-terminus load error

### DIFF
--- a/angelslim/engine.py
+++ b/angelslim/engine.py
@@ -75,6 +75,7 @@ class Engine:
         deploy_backend="vllm",
         using_multi_nodes=False,
         use_audio_in_video=False,
+        attn_implementation="default",
     ) -> Any:
         """Load pretrained model and tokenizer
         Args:
@@ -92,6 +93,8 @@ class Engine:
             cache_dir (str, optional): Directory to cache the model.
             deploy_backend (str): Backend for deployment, e.g., "torch", "vllm".
             using_multi_nodes (bool): Whether to use multi-nodes for calibration.
+            use_audio_in_video (bool): Whether to add audio track to a video file.
+            attn_implementation (str): The attention implementation to use in the model.
         """
         assert model_name, "model_name must be specified."
         assert model_path, "model_path must be specified."
@@ -126,6 +129,7 @@ class Engine:
                     device_map=device_map,
                     trust_remote_code=trust_remote_code,
                     use_audio_in_video=use_audio_in_video,
+                    attn_implementation=attn_implementation,
                 )
                 self.model_path = model_path
         else:

--- a/angelslim/models/omni/qwen3_omni.py
+++ b/angelslim/models/omni/qwen3_omni.py
@@ -47,14 +47,22 @@ class Qwen_Omni(BaseLLMModel):
         device_map="auto",
         trust_remote_code=True,
         use_audio_in_video=False,
+        attn_implementation="default",
     ):
         self.use_audio_in_video = use_audio_in_video
-        self.model = Qwen3OmniMoeForConditionalGeneration.from_pretrained(
-            model_path,
-            torch_dtype=torch_dtype,
-            device_map=device_map,
-            attn_implementation="flash_attention_2",
-        )
+        if attn_implementation == "default":
+            self.model = Qwen3OmniMoeForConditionalGeneration.from_pretrained(
+                model_path,
+                torch_dtype=torch_dtype,
+                device_map=device_map,
+            )
+        else:
+            self.model = Qwen3OmniMoeForConditionalGeneration.from_pretrained(
+                model_path,
+                torch_dtype=torch_dtype,
+                device_map=device_map,
+                attn_implementation=attn_implementation,
+            )
 
         # Load tokenizer
         self.tokenizer = AutoTokenizer.from_pretrained(

--- a/angelslim/utils/config_parser.py
+++ b/angelslim/utils/config_parser.py
@@ -121,6 +121,8 @@ class ModelConfig:
         low_cpu_mem_usage: Use low memory loading for large models
         use_cache: Whether to use cache during model loading
         cache_dir: Directory for caching model files
+        use_audio_in_video: Whether to add audio track to a video file
+        attn_implementation: The attention implementation to use in the model
     """
 
     name: str
@@ -132,6 +134,7 @@ class ModelConfig:
     use_cache: bool = field(default=False)
     cache_dir: Optional[str] = field(default=None)
     use_audio_in_video: bool = field(default=False)
+    attn_implementation: str = field(default="default")
 
 
 @dataclass

--- a/configs/qwen3_omni/fp8_dynamic/qwen3_omni_fp8_dynamic.yaml
+++ b/configs/qwen3_omni/fp8_dynamic/qwen3_omni_fp8_dynamic.yaml
@@ -12,6 +12,7 @@ model:
   torch_dtype: auto
   device_map: auto
   use_audio_in_video: false
+  attn_implementation: default
 
 # Compression configuration
 compression:

--- a/configs/qwen3_omni/fp8_static/qwen3_omni_fp8_static.yaml
+++ b/configs/qwen3_omni/fp8_static/qwen3_omni_fp8_static.yaml
@@ -12,6 +12,7 @@ model:
   torch_dtype: auto
   device_map: auto
   use_audio_in_video: false
+  attn_implementation: default
 
 # Compression configuration
 compression:

--- a/docs/source/models/qwen3_omni/qwen3_omni_quant.md
+++ b/docs/source/models/qwen3_omni/qwen3_omni_quant.md
@@ -15,6 +15,7 @@ FP8量化的配置文件可参考路径：`configs/qwen3_omni/fp8_static` 和 `c
 - `name`：模型名称，固定填写`Qwen_Omni`。
 - `model_path`：可填写hugging face模型卡片名称或者本地路径。
 - `use_audio_in_video`: 用于控制是否使用源视频的音频轨道
+- `attn_implementation`: 模型中要使用的注意力实现，默认值为`default`，设为`flash_attention_2`可以降低GPU显存占用
 
 #### compression配置
 - `name`：压缩策略类型，固定选择量化模式`PTQ`。
@@ -27,6 +28,14 @@ FP8量化的配置文件可参考路径：`configs/qwen3_omni/fp8_static` 和 `c
 - `data_path`：数据集路径，支持jsonl文件路径。自定义数据集需参考`dataset/omni_fake_data/fake_data.json`格式。
 
 ### 启动量化流程
+
+若在`model`配置中设置了`attn_implementation`为`flash_attention_2`，需要另外安装`FlashAttention 2`：
+```shell
+pip install -U flash-attn --no-build-isolation
+
+# ldd --version 如果 < 2.32，可降到 2.7.4.post1 以下版本
+pip install flash-attn==2.7.4.post1 --no-build-isolation
+```
 
 通过以下命令启动FP8量化校准：
 

--- a/tools/run.py
+++ b/tools/run.py
@@ -91,6 +91,7 @@ def multi_nodes_run(config):
         use_cache=model_config.use_cache,
         cache_dir=model_config.cache_dir,
         use_audio_in_video=model_config.use_audio_in_video,
+        attn_implementation=model_config.attn_implementation,
         deploy_backend=global_config.deploy_backend,
         using_multi_nodes=True,
     )
@@ -151,6 +152,7 @@ def run(config):
         use_cache=model_config.use_cache,
         cache_dir=model_config.cache_dir,
         use_audio_in_video=model_config.use_audio_in_video,
+        attn_implementation=model_config.attn_implementation,
         deploy_backend=global_config.deploy_backend,
     )
 


### PR DESCRIPTION
- Add attn_implementation to model config; for Qwen3-Omni quantization, it can be passed via the [config](https://github.com/Tencent/AngelSlim/tree/main/configs/qwen3_omni).
- Add instructions for installing FlashAttention2 package when attn_implementation is set to flash_attention_2 for [Qwen3-Omni.](https://github.com/Tencent/AngelSlim/blob/main/docs/source/models/qwen3_omni/qwen3_omni_quant.md)
- Fix the data type mismatch error when loading layerorm weight for DeepSeekV3.1-Terminus under torchrun startup with fp8 loading.