### PR TITLE
fix bos_token is None in TextDataset

### DIFF
--- a/angelslim/data/text_dataset.py
+++ b/angelslim/data/text_dataset.py
@@ -102,7 +102,11 @@ class TextDataset(BaseDataset):
                             thinking_data = True
                             break
                 if thinking_data:
-                    text = self.processor.bos_token
+                    text = (
+                        self.processor.bos_token
+                        if self.processor.bos_token is not None
+                        else ""
+                    )
                     for dic in messages:
                         if dic["role"] == "system":
                             text += dic["content"]


### PR DESCRIPTION
- Fixed an issue where the tokenizer would throw the error below when processing text data containing thought content and the bos_token is set to None.
Error: `TypeError: unsupported operand type(s) for +: 'NoneType' and 'str' `
