### PR TITLE
skip getting `sub_config_name` attribute for text2text model

### DIFF
--- a/angelslim/compressor/speculative/train/models/target/target_head.py
+++ b/angelslim/compressor/speculative/train/models/target/target_head.py
@@ -85,12 +85,15 @@ class TargetHead(nn.Module):
         """
         # Load model config to get architecture info
         config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=True)
-        if hasattr(config, sub_config_name):
-            config = getattr(config, sub_config_name)
-        else:
-            raise ValueError(
-                f"Config {config} has no sub-config named {sub_config_name}"
-            )
+
+        if sub_config_name is not None:
+            # now sub_config_name is only for VLM models to get language_model config
+            if hasattr(config, sub_config_name):
+                config = getattr(config, sub_config_name)
+            else:
+                raise ValueError(
+                    f"Config {config} has no sub-config named {sub_config_name}"
+                )
 
         # Get model dimensions
         hidden_size = config.hidden_size

--- a/angelslim/compressor/speculative/train/models/target/target_model_wrapper.py
+++ b/angelslim/compressor/speculative/train/models/target/target_model_wrapper.py
@@ -274,22 +274,6 @@ class TransformersBackend(BaseBackend):
         }
 
 
-class VLMForwardWrapper(torch.nn.Module):
-    def __init__(self, model):
-        super().__init__()
-        self.model = model
-
-    def forward(self, *args, **kwargs):
-        inputs_embeds = None
-        if "inputs_embeds" in kwargs and kwargs["inputs_embeds"] is not None:
-            inputs_embeds = kwargs["inputs_embeds"]
-        elif len(args) > 2 and args[2] is not None:
-            inputs_embeds = args[2]
-
-        outputs = self.model.forward(*args, **kwargs)
-        return outputs, inputs_embeds
-
-
 class VLMTransformersBackend(BaseBackend):
     """VLM HuggingFace Transformers backend"""
 
@@ -306,7 +290,6 @@ class VLMTransformersBackend(BaseBackend):
         self.model = AutoModelForImageTextToText.from_pretrained(
             self.model_path, **default_kwargs
         )
-        # self.model = VLMForwardWrapper(self.model)
 
         # Freeze the base model
         for param in self.model.parameters():

--- a/tools/train_eagle3_online.py
+++ b/tools/train_eagle3_online.py
@@ -275,7 +275,7 @@ def train():
     # Create draft model
     rank0_print("Loading draft model...")
     draft_model_config = DraftModelConfig.from_file(args.draft_model_config_path)
-    print(f"draft_model_config: {draft_model_config}")
+    rank0_print(f"draft_model_config: {draft_model_config}")
     draft_model = create_draft_model(draft_model_config)
     draft_model.load_embed_weights(args.target_model_name_or_path)
     draft_model.freeze_embed_weights()


### PR DESCRIPTION
1. skip getting `sub_config_name` attribute for text2text model. `sub_config_name` now is only used for VLM models.
2. remove unused code.