### PR TITLE
feat(qat): add KV cache quantization support in QAT pipeline

### DIFF
--- a/angelslim/compressor/qat/modules/quantizer.py
+++ b/angelslim/compressor/qat/modules/quantizer.py
@@ -30,6 +30,12 @@ def clamp_ste(x: torch.Tensor, min_val, max_val):
     return (x.clamp(min_val, max_val) - x).detach() + x
 
 
+def fp8_cast_ste(x: torch.Tensor):
+    """Simulate FP8 E4M3 cast with STE for gradient pass-through."""
+    x_fp8 = x.to(torch.float8_e4m3fn)
+    return (x_fp8.to(x.dtype) - x).detach() + x
+
+
 def _parse_bits_and_dtype(qtype_str):
     match = re.search(r"\d+", qtype_str)
     if match is None:
@@ -43,9 +49,10 @@ def _parse_bits_and_dtype(qtype_str):
 
 
 class Quantizer(nn.Module):
-    def __init__(self, config, quant_info, x=None, is_act=False, resume=False):
+    def __init__(self, config, quant_info, x=None, is_act=False, resume=False, num_heads=-1):
         super().__init__()
         self.is_act = is_act
+        self.num_heads = num_heads
         info = quant_info.quant_algo_info["w"]
         self.group_size = quant_info.quant_algo_info.get("w_group_size", -1)
         rewrite_conf = config.get("weight", {})
@@ -142,6 +149,7 @@ class Quantizer(nn.Module):
             s = torch.clamp(x_g.abs().max(dim=-1)[0], min=1e-8)  # shape: [out_channels, n_groups]
 
         elif granularity == "per-token":
+            init_shape = x.shape
             rx = x.reshape(-1, x.shape[-1])
             tmp = torch.zeros(rx.shape[0], device=x.device, dtype=x.dtype)
             xmax = torch.maximum(
@@ -150,6 +158,30 @@ class Quantizer(nn.Module):
             )
             s = xmax.unsqueeze(1)  # shape: [n_tokens, 1]
             s[xmax == 0] = 1
+            # Reshape scale back to match original input dims, e.g. [B, S, 1]
+            if len(init_shape) > 2:
+                s = s.reshape(*init_shape[:-1], 1)
+
+        elif granularity == "per-head":
+            # Per-head: reshape [..., num_heads * head_dim] -> [..., num_heads, head_dim]
+            # then reduce over all dims except num_heads to get scale shape (num_heads,)
+            assert self.num_heads > 0, "num_heads must be set for per-head granularity"
+            head_dim = x.shape[-1] // self.num_heads
+            x_heads = x.view(*x.shape[:-1], self.num_heads, head_dim)
+            # Flatten all dims except the num_heads dim, then take max per head
+            # x_heads: [..., num_heads, head_dim] -> reduce all except dim -2
+            s = (
+                torch.clamp(
+                    x_heads.abs().flatten(0, -3).amax(dim=(0, -1)),  # shape: (num_heads,)
+                    min=1e-8,
+                )
+                if x_heads.dim() > 2
+                else torch.clamp(
+                    x_heads.abs().amax(dim=-1),  # shape: (num_heads,)
+                    min=1e-8,
+                )
+            )
+
         else:
             raise ValueError(f"Unsupported granularity: {granularity}")
 
@@ -202,6 +234,29 @@ class Quantizer(nn.Module):
             zp = torch.round(-xmin / s) + self.qmin
             s = s.unsqueeze(1)
             zp = zp.unsqueeze(1)
+
+        elif granularity == "per-head":
+            # Per-head: reshape [..., num_heads * head_dim] -> [..., num_heads, head_dim]
+            # then reduce over all dims except num_heads to get scale/zp shape (num_heads,)
+            assert self.num_heads > 0, "num_heads must be set for per-head granularity"
+            head_dim = x.shape[-1] // self.num_heads
+            x_heads = x.view(*x.shape[:-1], self.num_heads, head_dim)
+            if x_heads.dim() > 2:
+                flat = x_heads.flatten(0, -3)  # (N, num_heads, head_dim)
+                reduce_dims = (0, -1)
+            else:
+                flat = x_heads  # (num_heads, head_dim)
+                reduce_dims = (-1,)
+            tmp = torch.zeros(self.num_heads, device=x.device, dtype=x.dtype)
+            xmin = torch.minimum(flat.amin(dim=reduce_dims), tmp)  # (num_heads,)
+            xmax = torch.maximum(flat.amax(dim=reduce_dims), tmp)  # (num_heads,)
+            mask = xmin == xmax
+            xmin[mask], xmax[mask] = -1.0, 1.0
+            s = torch.clamp((xmax - xmin) / (self.qmax - self.qmin), min=1e-8)
+            zp = torch.round(-xmin / s) + self.qmin
+
+        else:
+            raise ValueError(f"Unsupported granularity: {granularity}")
 
         zp = torch.clamp(
             zp if isinstance(zp, torch.Tensor) else torch.tensor(zp),
@@ -312,7 +367,14 @@ class Quantizer(nn.Module):
 
 class QuantLinear(nn.Module):
     def __init__(
-        self, org_module, config, quant_info, use_weight_quant, use_act_quant, resume=False
+        self,
+        org_module,
+        config,
+        quant_info,
+        use_weight_quant,
+        use_act_quant,
+        resume=False,
+        qkv_config=None,
     ):
         super().__init__()
         self.fwd_func = F.linear
@@ -327,6 +389,15 @@ class QuantLinear(nn.Module):
         if self.use_act_quant:
             self.act_quantizer = Quantizer(config, quant_info, is_act=True, resume=resume)
 
+        # QKV output quantization for KV cache compression simulation
+        self.use_qkv_quant = qkv_config is not None
+        if self.use_qkv_quant:
+            qkv_cfg = {**config, "activation": qkv_config}
+            num_heads = qkv_config.get("num_heads", -1) if isinstance(qkv_config, dict) else -1
+            self.qkv_quantizer = Quantizer(
+                qkv_cfg, quant_info, is_act=True, resume=resume, num_heads=num_heads
+            )
+
     def forward(self, input: torch.Tensor):
         if input.shape[0] == 0:
             return self.fwd_func(input, self.weight, self.bias)
@@ -334,8 +405,14 @@ class QuantLinear(nn.Module):
         weight = self.weight_quantizer(self.weight) if self.use_weight_quant else self.weight
         if self.use_act_quant:
             input = self.act_quantizer(input)
-        return self.fwd_func(input, weight, self.bias)
+        output = self.fwd_func(input, weight, self.bias)
+        if self.use_qkv_quant:
+            output = self.qkv_quantizer(output)
+        return output
 
-    def set_quant_state(self, weight_quant=False, act_quant=False):
+    def set_quant_state(self, weight_quant=False, act_quant=False, qkv_quant=None):
         self.use_weight_quant = weight_quant
         self.use_act_quant = act_quant
+        if qkv_quant is not None:
+            # Only enable qkv_quant if this module actually has a qkv_quantizer
+            self.use_qkv_quant = qkv_quant and hasattr(self, "qkv_quantizer")

--- a/angelslim/compressor/qat/plugins/learnable_scale.py
+++ b/angelslim/compressor/qat/plugins/learnable_scale.py
@@ -20,6 +20,12 @@ from ..modules.quantizer import QuantLinear
 from .base_plugin import BasePlugin
 from .plugin_manager import PluginManager
 
+_QKV_PROJ_MAP = {
+    "q_proj": "q",
+    "k_proj": "k",
+    "v_proj": "v",
+}
+
 
 @PluginManager.plugin("learnable_scale")
 class LearnableScalePlugin(BasePlugin):
@@ -30,12 +36,30 @@ class LearnableScalePlugin(BasePlugin):
         self.resume_ckpt_dir = resume_ckpt_dir
         self.use_weight_quant = self.config.get("use_weight_quant", False)
         self.use_activation_quant = self.config.get("use_activation_quant", False)
+        self.fp8_attn = self.config.get("fp8_attn", False)
+
+        # Parse learnable config (boolean switches for each parameter group)
+        learnable_cfg = self.config.get("learnable", {})
+        self.learn_act_scale = learnable_cfg.get("act_scale", True)
+        self.learn_weight_scale = learnable_cfg.get("weight_scale", False)
+        self.learn_kv_scale = learnable_cfg.get("kv_scale", False)
+        self.learn_norm = learnable_cfg.get("norm", False)
 
     def before_train(self, **kwargs):
+        # Retrieve KV head count from model config for per-head quantization
+        model_config = getattr(self.quant_model.model, "config", None)
+        num_kv_heads = getattr(model_config, "num_key_value_heads", -1)
         for name, module in self.quant_model.model.named_modules():
             if isinstance(module, torch.nn.Linear):
                 if any(ig in name for ig in self.ignore_layers):
                     continue
+
+                qkv_cfg = _get_qkv_config_for_layer(name, self.config)
+                # Inject num_heads into qkv_config for per-head granularity
+                if qkv_cfg is not None:
+                    suffix = name.rsplit(".", 1)[-1]
+                    if suffix in ("k_proj", "v_proj"):
+                        qkv_cfg["num_heads"] = num_kv_heads
                 q_linear = QuantLinear(
                     module,
                     self.config,
@@ -43,8 +67,13 @@ class LearnableScalePlugin(BasePlugin):
                     self.use_weight_quant,
                     self.use_activation_quant,
                     resume=self.resume_ckpt_dir is not None,
+                    qkv_config=qkv_cfg,
                 )
                 set_op_by_name(self.quant_model.model, name, q_linear)
+
+        # FP8 attention simulation — delegate to model (model-specific override)
+        if self.fp8_attn:
+            self.quant_model.patch_fp8_attention()
 
         print_info(self.quant_model.model)
 
@@ -55,8 +84,37 @@ class LearnableScalePlugin(BasePlugin):
         ):
             self._lazy_init(**kwargs)
 
-        set_quant_parameters(self.quant_model.model, requires_grad=True)
-        set_weight_parameters(self.quant_model.model, requires_grad=False)
+        self._apply_learn_strategy()
+
+    def _apply_learn_strategy(self):
+        """Set requires_grad on parameters according to ``learnable`` config."""
+        model = self.quant_model.model
+
+        # Freeze everything first
+        set_quant_parameters(model, requires_grad=False)
+        set_weight_parameters(model, requires_grad=False)
+
+        # Selectively enable each parameter group based on boolean switches
+        _set_learnable_parameters(
+            model,
+            act_scale=self.learn_act_scale,
+            weight_scale=self.learn_weight_scale,
+            kv_scale=self.learn_kv_scale,
+        )
+
+        if self.learn_norm:
+            _set_norm_parameters(model, requires_grad=True)
+
+        learnable_summary = (
+            f"act_scale={self.learn_act_scale}, "
+            f"weight_scale={self.learn_weight_scale}, "
+            f"kv_scale={self.learn_kv_scale}, "
+            f"norm={self.learn_norm}"
+        )
+        print_info(
+            f"Learnable config ({learnable_summary}): "
+            f"{sum(1 for p in model.parameters() if p.requires_grad)} trainable params"
+        )
 
     def after_train(self):
         if self.use_weight_quant:
@@ -66,7 +124,7 @@ class LearnableScalePlugin(BasePlugin):
             )
 
     def _lazy_init(self, **kwargs):
-        set_quant_state(self.quant_model.model, weight_quant=False, act_quant=True)
+        set_quant_state(self.quant_model.model, weight_quant=False, act_quant=True, qkv_quant=True)
 
         init_samples = self.config.get("lazy_init_samples", 10)
         for i in tqdm(range(init_samples), desc="Lazy init"):
@@ -79,50 +137,53 @@ class LearnableScalePlugin(BasePlugin):
             with torch.no_grad():
                 self.quant_model.model(**inputs)
 
-        for _, module in self.quant_model.model.named_modules():
+        for name, module in self.quant_model.model.named_modules():
             if isinstance(module, QuantLinear):
-                module.act_quantizer.init = True
-                if not module.act_quantizer.dynamic and not isinstance(
-                    module.act_quantizer.scale, torch.nn.Parameter
-                ):  # for MoE
-                    if not hasattr(module.act_quantizer, "overall_scale"):
-                        scale = torch.tensor(
-                            1.0, dtype=module.weight.dtype, device=module.weight.device
-                        )
-                        zp = (
-                            torch.tensor(0.0, dtype=scale.dtype, device=scale.device)
-                            if not module.act_quantizer.is_sym
-                            else None
-                        )
-                        module.act_quantizer._set_quant_parameters(scale, zp)
-                        print_info(
-                            f"Not calibrate, init scale: {module.act_quantizer.scale.item()}"
-                        )
-                    else:
-                        max_scale = max(module.act_quantizer.overall_scale)
-                        max_idx = module.act_quantizer.overall_scale.index(max_scale)
-                        zp = (
-                            module.act_quantizer.overall_zero_point[max_idx]
-                            if not module.act_quantizer.is_sym
-                            else None
-                        )
-                        module.act_quantizer._set_quant_parameters(max_scale, zp)
-                        print_info(
-                            f"Lazy init done, scale: {module.act_quantizer.scale.item()}, samples: {module.act_quantizer.calib_count}"  # noqa: E501
-                        )
-                        del (
-                            module.act_quantizer.overall_scale,
-                            module.act_quantizer.overall_zero_point,
-                            module.act_quantizer.calib_count,
-                        )
+                dtype, device = module.weight.dtype, module.weight.device
+                _finalize_quantizer(module.act_quantizer, dtype, device, tag="act")
+                if module.use_qkv_quant:
+                    _finalize_quantizer(module.qkv_quantizer, dtype, device, tag=f"qkv({name})")
 
         set_quant_state(self.quant_model.model, weight_quant=self.use_weight_quant, act_quant=True)
 
 
-def set_quant_state(model, weight_quant=False, act_quant=False):
+def _finalize_quantizer(quantizer, dtype, device, tag=""):
+    if quantizer.dynamic:
+        return
+    quantizer.init = True
+    if isinstance(quantizer.scale, torch.nn.Parameter):
+        return
+    label = getattr(quantizer, "role", tag)
+    if not hasattr(quantizer, "overall_scale") or not quantizer.overall_scale:
+        scale = torch.tensor(1.0, dtype=dtype, device=device)
+        zp = torch.tensor(0.0, dtype=dtype, device=device) if not quantizer.is_sym else None
+        quantizer._set_quant_parameters(scale, zp)
+        print_info(f"Lazy init ({label}): no calib, init scale=1.0")
+    else:
+        scale = quantizer.overall_scale[0]
+        for s in quantizer.overall_scale[1:]:
+            scale = torch.maximum(scale, s)
+        zp = None
+        if hasattr(quantizer, "overall_zero_point") and not quantizer.is_sym:
+            zp = quantizer.overall_zero_point[0]
+            for z in quantizer.overall_zero_point[1:]:
+                zp = torch.maximum(zp, z)
+        quantizer._set_quant_parameters(scale, zp)
+        print_info(
+            f"Lazy init ({label}) done, scale: {quantizer.scale.max().item():.4f}, samples: {quantizer.calib_count}"  # noqa: E501
+        )
+        if hasattr(quantizer, "overall_zero_point"):
+            del quantizer.overall_scale, quantizer.overall_zero_point, quantizer.calib_count
+        else:
+            del quantizer.overall_scale, quantizer.calib_count
+
+
+def set_quant_state(model, weight_quant=False, act_quant=False, qkv_quant=None):
     for module in model.modules():
         if isinstance(module, QuantLinear):
-            module.set_quant_state(weight_quant=weight_quant, act_quant=act_quant)
+            module.set_quant_state(
+                weight_quant=weight_quant, act_quant=act_quant, qkv_quant=qkv_quant
+            )
 
 
 def set_quant_parameters(model, requires_grad):
@@ -163,6 +224,51 @@ def trainable_parameters(model):
         if m.requires_grad:
             params.append(m)
     return iter(params)
+
+
+def _set_learnable_parameters(model, act_scale=False, weight_scale=False, kv_scale=False):
+    _KV_SUFFIXES = ("k_proj", "v_proj")
+
+    for name, module in model.named_modules():
+        if not isinstance(module, QuantLinear):
+            continue
+
+        if act_scale and hasattr(module, "act_quantizer"):
+            for pname, param in module.act_quantizer.named_parameters():
+                if "scale" in pname or "zero_point" in pname:
+                    param.requires_grad = True
+
+        if weight_scale and hasattr(module, "weight_quantizer"):
+            for pname, param in module.weight_quantizer.named_parameters():
+                if "scale" in pname or "zero_point" in pname:
+                    param.requires_grad = True
+
+        if kv_scale and hasattr(module, "qkv_quantizer"):
+            suffix = name.rsplit(".", 1)[-1] if "." in name else name
+            if suffix in _KV_SUFFIXES:
+                for pname, param in module.qkv_quantizer.named_parameters():
+                    if "scale" in pname or "zero_point" in pname:
+                        param.requires_grad = True
+
+
+def _set_norm_parameters(model, requires_grad):
+    """Enable/disable gradient for norm layer (RMSNorm / LayerNorm) weight parameters."""
+    for name, param in model.named_parameters():
+        # Match typical norm layer parameter names, e.g.
+        #   input_layernorm.weight, post_attention_layernorm.weight, norm.weight
+        if "norm" in name and "weight" in name:
+            param.requires_grad = requires_grad
+
+
+def _get_qkv_config_for_layer(name, quant_config):
+    suffix = name.rsplit(".", 1)[-1] if "." in name else name
+    qkv_key = _QKV_PROJ_MAP.get(suffix)
+    if qkv_key is None:
+        return None
+    qkv_section = quant_config.get(qkv_key)
+    if qkv_section is None:
+        return None
+    return dict(qkv_section)
 
 
 @torch.no_grad()

--- a/angelslim/compressor/qat/qat.py
+++ b/angelslim/compressor/qat/qat.py
@@ -15,6 +15,7 @@
 import os
 
 import torch
+from safetensors.torch import save_file
 
 from ...utils import print_info, set_op_by_name
 from ..compressor_factory import CompressorFactory
@@ -72,7 +73,7 @@ class QAT:
         self.trainer.run(dataloader)
 
     def convert(self):
-        if self.save_fmt != "real":
+        if self.save_fmt not in ("real", "real_and_kvcache"):
             return
 
         print_info("Start QAT convert: replacing QuantLinear with QDQModule...")
@@ -109,7 +110,31 @@ class QAT:
             )
             set_op_by_name(self.quant_model.model, name, qdq_module)
 
+    def _save_kv_cache_scales(self, save_path: str):
+        """Extract and save KV cache scales to a safetensors file."""
+        kv_scales = {}
+        for name, module in self.quant_model.model.named_modules():
+            if not isinstance(module, QuantLinear):
+                continue
+            if not module.use_qkv_quant or not hasattr(module, "qkv_quantizer"):
+                continue
+            # Map k_proj / v_proj to k_cache / v_cache
+            if name.endswith(".k_proj"):
+                cache_name = name.replace(".k_proj", ".k_cache")
+            elif name.endswith(".v_proj"):
+                cache_name = name.replace(".v_proj", ".v_cache")
+            else:
+                continue
+            scale_key = f"{cache_name}.scale"
+            kv_scales[scale_key] = module.qkv_quantizer.scale.data.clone().float().cpu()
+
+        os.makedirs(save_path, exist_ok=True)
+        out_file = os.path.join(save_path, "kv_cache_scales.safetensors")
+        save_file(kv_scales, out_file)
+        print_info(f"Saved {len(kv_scales)} KV cache scales to: {out_file}")
+
     def save(self, save_path: str):
+        # "fake": save fake-quant state_dict (NOTE: only supports non-distributed / single-GPU)
         if self.save_fmt == "fake":
             parts = save_path.rsplit("/")
             save_path = os.path.join("/".join(parts[:-1]), parts[-1] + "_fake_quant_model.pt")
@@ -118,9 +143,20 @@ class QAT:
             cpu_state = self.trainer.external_trainer.model.state_dict()
             torch.save(cpu_state, save_path)
 
+        # "real": save real-quant model via model-specific save function
         elif self.save_fmt == "real":
             save_func = self.quant_model.get_save_func()(self.quant_model)
             save_func.save(os.path.join(save_path, "final_quant_checkpoint"))
+
+        # "save_kvcache_only": only export KV cache scales (kv_cache_scales.safetensors)
+        elif self.save_fmt == "save_kvcache_only":
+            self._save_kv_cache_scales(os.path.join(save_path, "final_quant_checkpoint"))
+
+        # "real_and_kvcache": save real-quant model AND KV cache scales
+        elif self.save_fmt == "real_and_kvcache":
+            save_func = self.quant_model.get_save_func()(self.quant_model)
+            save_func.save(os.path.join(save_path, "final_quant_checkpoint"))
+            self._save_kv_cache_scales(os.path.join(save_path, "final_quant_checkpoint"))
 
         else:
             print_info("Save format not specified, skip save.")

--- a/angelslim/compressor/qat/trainers/end2end_trainer.py
+++ b/angelslim/compressor/qat/trainers/end2end_trainer.py
@@ -42,7 +42,7 @@ class End2EndTrainer:
         if self.training_mode == "end2end" and self.dist_mode == "hf":
             self.external_trainer = Seq2SeqTrainer(
                 model=self.quant_model.model,
-                tokenizer=self.quant_model.tokenizer,
+                processing_class=self.quant_model.tokenizer,
                 args=Seq2SeqTrainingArguments(
                     output_dir=self.config["global_config"].save_path,
                     **self.config["compress_config"].QAT.hf_args,

--- a/angelslim/engine.py
+++ b/angelslim/engine.py
@@ -121,6 +121,7 @@ class Engine:
                     low_cpu_mem_usage=low_cpu_mem_usage,
                     use_cache=use_cache,
                     using_multi_nodes=using_multi_nodes,
+                    attn_implementation=attn_implementation,
                 )
                 self.model_path = model_path
         elif self.series in ["Omni"]:

--- a/angelslim/models/base_model.py
+++ b/angelslim/models/base_model.py
@@ -51,6 +51,8 @@ class BaseLLMModel(metaclass=ABCMeta):
         self.modal_type = "LLM"
         self.pre_transformer_module_names = ["model.embed_tokens"]
         self.observer_layer_classes = [torch.nn.Linear]
+        # Store original forward methods for restoration
+        self._original_attn_forwards = {}
 
     def from_pretrained(
         self,
@@ -61,14 +63,20 @@ class BaseLLMModel(metaclass=ABCMeta):
         low_cpu_mem_usage=True,
         use_cache=False,
         using_multi_nodes=False,
+        attn_implementation="default",
     ):
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_path,
+        kwargs = dict(
             torch_dtype=torch_dtype,
             device_map=device_map,
             trust_remote_code=trust_remote_code,
             low_cpu_mem_usage=low_cpu_mem_usage,
             use_cache=use_cache,
+        )
+        if attn_implementation != "default":
+            kwargs["attn_implementation"] = attn_implementation
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_path,
+            **kwargs,
         )
 
         # Load tokenizer
@@ -180,6 +188,9 @@ class BaseLLMModel(metaclass=ABCMeta):
             for k in observe_names
             if k.startswith(self.block_name) and k.split(".")[-2] + "." + k.split(".")[-1] in names
         ]
+
+    def patch_fp8_attention(self):
+        print_info("Warning: patch_fp8_attention not implemented for this model, skipping")
 
     def get_quant_config(self):
         assert self.quant_config is not None

--- a/angelslim/models/llm/qwen.py
+++ b/angelslim/models/llm/qwen.py
@@ -16,13 +16,15 @@ import re
 
 import torch
 import torch.nn as nn
+from transformers.models.qwen3.modeling_qwen3 import apply_rotary_pos_emb, repeat_kv
 from transformers.models.qwen3_moe.modeling_qwen3_moe import (
     Qwen3MoeExperts,
     Qwen3MoeTopKRouter,
 )
 
+from ...compressor.qat.modules.quantizer import fp8_cast_ste
 from ...compressor.quant.core import PTQSaveVllmHF
-from ...utils.utils import find_layers, find_parent_layer_and_sub_name
+from ...utils.utils import find_layers, find_parent_layer_and_sub_name, print_info
 from ..base_model import BaseLLMModel
 from ..model_factory import SlimModelFactory
 
@@ -210,3 +212,84 @@ class Qwen(BaseLLMModel):
             input_observer_amax = self.input_observer_amax_dict[name]
 
         return weight_observer_amax, input_observer_amax
+
+    def get_attention_layers(self):
+        """Get all attention layers in the model."""
+        attention_layers = {}
+        for name, module in self.model.named_modules():
+            if name.endswith(".self_attn") and hasattr(module, "forward"):
+                # Verify it has k_proj and v_proj attributes
+                if hasattr(module, "k_proj") and hasattr(module, "v_proj"):
+                    attention_layers[name] = module
+        return attention_layers
+
+    def patch_fp8_attention(self):
+        attention_layers = self.get_attention_layers()
+
+        for attn_name, attn_module in attention_layers.items():
+            original_forward = attn_module.forward
+            self._original_attn_forwards.setdefault(attn_name, original_forward)
+
+            def _make_patched(attn_mod):
+                def patched_forward(
+                    hidden_states,
+                    position_embeddings,
+                    attention_mask=None,
+                    past_key_values=None,
+                    cache_position=None,
+                    **kwargs,
+                ):
+                    input_shape = hidden_states.shape[:-1]
+                    hidden_shape = (*input_shape, -1, attn_mod.head_dim)
+
+                    query_states = attn_mod.q_norm(
+                        attn_mod.q_proj(hidden_states).view(hidden_shape)
+                    ).transpose(1, 2)
+                    key_states = attn_mod.k_norm(
+                        attn_mod.k_proj(hidden_states).view(hidden_shape)
+                    ).transpose(1, 2)
+                    value_states = (
+                        attn_mod.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+                    )
+
+                    cos, sin = position_embeddings
+                    query_states, key_states = apply_rotary_pos_emb(
+                        query_states, key_states, cos, sin
+                    )
+
+                    if past_key_values is not None:
+                        cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+                        key_states, value_states = past_key_values.update(
+                            key_states, value_states, attn_mod.layer_idx, cache_kwargs
+                        )
+
+                    dropout = 0.0 if not attn_mod.training else attn_mod.attention_dropout
+                    key_states = repeat_kv(key_states, attn_mod.num_key_value_groups)
+                    value_states = repeat_kv(value_states, attn_mod.num_key_value_groups)
+
+                    attn_weights = (
+                        torch.matmul(query_states, key_states.transpose(2, 3)) * attn_mod.scaling
+                    )
+                    if attention_mask is not None:
+                        attn_weights = attn_weights + attention_mask
+
+                    attn_weights = nn.functional.softmax(
+                        attn_weights, dim=-1, dtype=torch.float32
+                    ).to(query_states.dtype)
+                    attn_weights = nn.functional.dropout(
+                        attn_weights, p=dropout, training=attn_mod.training
+                    )
+                    # === FP8 cast simulation ===
+                    attn_weights = fp8_cast_ste(attn_weights)
+                    attn_output = torch.matmul(attn_weights, value_states)
+                    attn_output = attn_output.transpose(1, 2).contiguous()
+
+                    attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+                    attn_output = attn_mod.o_proj(attn_output)
+                    return attn_output, attn_weights
+
+                return patched_forward
+
+            attn_module.forward = _make_patched(attn_module)
+
+        print_info(f"FP8 attention enabled for {len(attention_layers)} layers (patch forward)")

--- a/configs/qwen3/qat/w4a8_fp8/learn_scale/qwen3-4b_w4a8_fp8_end2end_learn_scale_qkv_fp8attn.yaml
+++ b/configs/qwen3/qat/w4a8_fp8/learn_scale/qwen3-4b_w4a8_fp8_end2end_learn_scale_qkv_fp8attn.yaml
@@ -1,0 +1,71 @@
+global:
+  save_path: ./output
+
+model:
+  name: Qwen
+  model_path: Qwen/Qwen3-4B
+  trust_remote_code: true
+  torch_dtype: auto
+  device_map: auto
+  low_cpu_mem_usage: true
+  use_cache: false
+
+compression:
+  name: QAT
+  quantization:
+    name: w4a8_fp8
+    bits: 8
+    quant_method:
+      weight: per-group
+      activation: per-tensor
+      group_size: 128
+    ignore_layers: ["lm_head", "embed_tokens"] # Skip quantization for these layers
+  QAT:
+    hf_dataset: Salesforce/wikitext,wikitext-2-raw-v1 # hf dataset name, will overwrite dataset.data_path
+    # hf_cache_dir: Specify your cache path, or not set(default)
+    training_mode: end2end
+    dist_mode: hf # "hf" is using HF Trainer
+    save_format: save_kvcache_only # "save_kvcache_only": only export KV cache scales; "real": save real-quant model; "real_and_kvcache": save real-quant model + KV cache scales; "fake": save fake-quant state_dict (non-distributed only); or not set(skip save)
+    do_train: true
+    # resume_ckpt_dir: Resume for fake checkpoint, when save_format=='fake', or not set
+    plugin_config:
+      enable_scale: true
+      quant_config:
+        use_weight_quant: true
+        use_activation_quant: true
+        lazy_init_samples: 10
+        # --- Learnable parameter control ---
+        # Each switch independently controls whether that parameter group is trainable.
+        # Model weights themselves always stay frozen.
+        learnable:
+          act_scale: true             # Activation quantizer scale/zero_point (default: true)
+          weight_scale: false         # Weight quantizer scale/zero_point (default: false)
+          kv_scale: false             # KV cache quantizer scale in k_proj/v_proj (default: false)
+          norm: false                 # Norm layer (RMSNorm/LayerNorm) weights (default: false)
+        # --- QKV / Attention FP8 quantization ---
+        fp8_attn: true              # Enable FP8 attention simulation (cast attn_weights to FP8)
+        q:                          # Query projection output quantization
+          qtype: fp8
+          granularity: per-token    # Dynamic per-token quantization for Q
+          group_size: -1
+          is_sym: true
+        k:                          # Key projection output quantization (KV cache compression)
+          qtype: fp8
+          granularity: per-head     # Per-head quantization, one scale per KV head
+          group_size: -1
+          is_sym: true
+        v:                          # Value projection output quantization (KV cache compression)
+          qtype: fp8
+          granularity: per-head
+          group_size: -1
+          is_sym: true
+    hf_args:
+      # output_dir: Not to set, same as global.save_path
+      # other arguments, see https://huggingface.co/docs/transformers/v5.1.0/en/main_classes/trainer#transformers.Seq2SeqTrainingArguments
+
+dataset:
+  name: TextDataset
+  data_path: ./dataset/sharegpt_gpt4_qwen/sharegpt_gpt4-qwen3_a22B_output.jsonl
+  max_seq_length: 2048
+  num_samples: 256
+  batch_size: 1

--- a/docs/source/features/quantization/qat.md
+++ b/docs/source/features/quantization/qat.md
@@ -74,7 +74,15 @@ angelslim/data/
 4. **训练**：根据配置选择端到端训练或逐块训练模式
 5. **插件 `after_train`**：执行训练后处理
 6. **转换**：`convert()` 将 `QuantLinear` 替换为推理用的 `QDQModule`
-7. **保存**：支持 `fake`（仅伪量化的 state_dict）和 `real`（真实量化模型）两种保存格式
+7. **保存**：支持以下保存格式：
+
+| `save_format` | 描述 | 备注 |
+|---------------|------|------|
+| `fake` | 保存伪量化的 state_dict（`.pt` 文件） | **仅支持非分布式 / 单卡** |
+| `real` | 保存真实量化模型（通过模型子类的 `get_save_func` 导出） | |
+| `save_kvcache_only` | 仅导出 KV Cache 的 scale 参数到 `kv_cache_scales.safetensors` | |
+| `real_and_kvcache` | 同时保存真实量化模型 **和** KV Cache scales | |
+| 不设置 | 跳过保存 | |
 
 ---
 
@@ -129,6 +137,29 @@ compression:
 | `per-channel` | 每个输出通道一组参数 | 通用权重量化 |
 | `per-group` | 每 `group_size` 个元素一组参数 | INT4 权重量化，精度更优 |
 | `per-token` | 每个 token 一组参数（始终为动态） | 激活动态量化 |
+| `per-head` | 每个 KV head 一组参数 | QKV 投影输出量化（KV Cache 压缩） |
+
+### QKV / Attention 量化配置
+
+QAT 支持对 Q/K/V 投影层的**输出**进行独立量化配置，用于模拟 KV Cache 量化压缩的精度损失，使模型在训练阶段感知 KV Cache 量化带来的影响。同时支持 FP8 Attention 模拟，对 softmax 后的 attention weights 执行 FP8 cast。
+
+QKV 量化配置位于 `compression.QAT.plugin_config.quant_config` 下，与 `weight` / `activation` 平级：
+
+| 配置项 | 类型 | 描述 |
+|--------|------|------|
+| `fp8_attn` | bool | 是否启用 FP8 Attention 模拟。启用后会 monkey-patch attention forward，对 attn_weights 执行 FP8 cast（需模型子类实现 `patch_fp8_attention`） |
+| `q` | dict | Query 投影输出的量化配置 |
+| `k` | dict | Key 投影输出的量化配置（KV Cache 中的 Key） |
+| `v` | dict | Value 投影输出的量化配置（KV Cache 中的 Value） |
+
+每个 `q` / `k` / `v` 配置字典支持以下字段：
+
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `qtype` | str | 量化类型，如 `fp8`、`int8` |
+| `granularity` | str | 量化粒度：`per-token`、`per-head`、`per-tensor`、`per-channel` |
+| `group_size` | int | 分组大小，`-1` 表示不分组 |
+| `is_sym` | bool | 是否对称量化 |
 
 ### dataset — 校准数据集配置
 
@@ -151,7 +182,7 @@ dataset:
   training_mode: "end2end"          # 训练模式："end2end" 或 "blockwise"
   dist_mode: "hf"                   # 分布式模式："hf"（HuggingFace Trainer）
   do_train: true                    # 是否执行训练
-  save_format: "real"               # 保存格式："fake" / "real" / 不设置表示跳过保存
+  save_format: "real"               # 保存格式（见下表），不设置表示跳过保存
   resume_ckpt_dir: ""               # checkpoint 恢复路径，用于加载 save_format 为 fake 的权重。不设置表示不使用 resume
 
   # ========== 数据集配置 ==========
@@ -166,6 +197,12 @@ dataset:
       use_weight_quant: true        # 是否量化权重
       use_activation_quant: true    # 是否量化激活
       lazy_init_samples: 60         # activation 校准所需的样本数（默认 10）
+      # ========== 可学习参数控制（可选） ==========
+      learnable:
+        act_scale: true             # 激活量化器的 scale/zero_point（默认：true）
+        weight_scale: false         # 权重量化器的 scale/zero_point（默认：false）
+        kv_scale: false             # KV Cache 量化器的 scale（默认：false）
+        norm: false                 # Norm 层权重（默认：false）
       # 可选：覆盖 compression.quantization 中的默认量化配置
       weight:
         qtype: int8                 # 权重量化类型（如 int4, int8, fp8）
@@ -177,6 +214,25 @@ dataset:
         granularity: per-tensor     # 激活量化粒度
         is_sym: true                # 是否对称量化
         dynamic: false              # 是否动态量化
+
+      # ========== QKV / Attention 量化配置（可选） ==========
+      fp8_attn: true                # 是否启用 FP8 Attention 模拟（对 attn_weights 做 FP8 cast）
+                                      # 注意：开启 fp8_attn 时，需要在 model 配置中设置 attn_implementation: eager
+      q:                            # Query 投影输出量化
+        qtype: fp8                  # 量化类型（fp8 / int8 等）
+        granularity: per-token      # 量化粒度（per-token / per-tensor）
+        group_size: -1              # 分组大小（-1 表示不分组）
+        is_sym: true                # 是否对称量化
+      k:                            # Key 投影输出量化（通常用于 KV Cache 压缩）
+        qtype: fp8
+        granularity: per-head       # per-head 粒度，每个 KV head 独立 scale
+        group_size: -1
+        is_sym: true
+      v:                            # Value 投影输出量化
+        qtype: fp8
+        granularity: per-head
+        group_size: -1
+        is_sym: true
 
 ```
 
@@ -269,9 +325,33 @@ def forward(self, input: torch.Tensor):
 
 1. 遍历模型所有 `nn.Linear` 层（跳过 `ignore_layers` 指定的层），替换为 `QuantLinear`
 2. 对静态 activation 量化执行 lazy 校准初始化
-3. **冻结模型权重**，仅让量化参数（`scale` / `zero_point`）可学习
+3. 根据 `learnable` 配置选择性地设置哪些参数可训练
 
-这意味着在 Learnable Scale 模式下，优化器实际更新的参数是各层的量化 scale 和 zero_point，而非模型原始权重。
+#### Learnable 参数控制
+
+通过 `learnable` 配置字典，可以独立控制每种参数组是否参与训练。模型权重本身始终保持冻结。
+
+```yaml
+plugin_config:
+  enable_scale: true
+  quant_config:
+    learnable:
+      act_scale: true           # 激活量化器的 scale/zero_point（默认：true）
+      weight_scale: false       # 权重量化器的 scale/zero_point（默认：false）
+      kv_scale: false           # KV Cache 量化器的 scale（k_proj/v_proj 中的 qkv_quantizer）（默认：false）
+      norm: false               # Norm 层（RMSNorm / LayerNorm）的权重（默认：false）
+```
+
+| 配置项 | 类型 | 默认值 | 描述 |
+|--------|------|--------|------|
+| `act_scale` | bool | `true` | 是否学习激活量化器（`act_quantizer`）的 scale / zero_point |
+| `weight_scale` | bool | `false` | 是否学习权重量化器（`weight_quantizer`）的 scale / zero_point |
+| `kv_scale` | bool | `false` | 是否学习 KV Cache 量化器（`qkv_quantizer`）的 scale（仅 k_proj / v_proj） |
+| `norm` | bool | `false` | 是否学习 Norm 层（如 `input_layernorm`、`post_attention_layernorm`）的 weight 参数 |
+
+各开关可以自由组合，例如同时开启 `weight_scale` 和 `kv_scale` 来联合优化权重量化和 KV Cache 量化的 scale 参数。
+
+> **注意**：如果未提供 `learnable` 配置，默认行为等价于 `act_scale: true`（其余为 `false`），即仅学习激活量化器的 scale 参数。
 
 ### TrainerFactory — 训练器工厂
 


### PR DESCRIPTION
This PR adds KV Cache quantization-aware training capability to the QAT pipeline. It enables FP8 quantization simulation for Q/K/V projection outputs and FP8 Attention weight casting, allowing end-to-end optimization of KV Cache quantization scales. 

**Changes**

Core Quantizer (angelslim/compressor/qat/modules/quantizer.py)

- Add per-head quantization granularity: reshapes tensor into [..., num_heads, head_dim] and computes an independent scale per head — designed for KV Cache quantization
- Fix per-token granularity to correctly reshape scale back to match multi-dimensional input shapes (e.g. [B, S, 1])

Learnable Scale Plugin (angelslim/compressor/qat/plugins/learnable_scale.py)

- Add FP8 Attention patching (_patch_fp8_attention): monkey-patches the model's attention forward to insert fp8_cast_ste on attn_weights before softmax, simulating FP8 Attention during training
- Implement fine-grained learnable parameter control via a learnable config dict:
act_scale: learn activation quantizer scales (default: true)
weight_scale: learn weight quantizer scales (default: false)
kv_scale: learn KV Cache quantizer scales on k_proj/v_proj (default: false)
norm: learn normalization layer weights (default: false)

QAT Orchestrator (angelslim/compressor/qat/qat.py)

- Parse new QKV quantization configs (q, k, v) and fp8_attn flag from plugin_config.quant_config
- Pass QKV config and fp8_attn flag through to the learnable scale plugin