### PR TITLE
fix(data): harden process_token_dict_to_mappings with explicit dtypes, O(1) lookup, and assertions

### DIFF
--- a/angelslim/compressor/speculative/train/data/data_utils.py
+++ b/angelslim/compressor/speculative/train/data/data_utils.py
@@ -133,10 +133,21 @@ def process_token_dict_to_mappings(
     used_tokens = [key for key, freq in top_N]
     used_tokens.sort()
 
-    d2t = [used_tokens[i] - i for i in range(len(used_tokens))]
-    t2d = [i in used_tokens for i in range(target_vocab_size)]
-    d2t = torch.tensor(d2t)
-    t2d = torch.tensor(t2d)
+    used_set = set(used_tokens)
+    d2t = torch.tensor(
+        [used_tokens[i] - i for i in range(len(used_tokens))],
+        dtype=torch.int64,  # must match register_buffer dtype in Eagle3LlamaForCausalLM
+    )
+    t2d = torch.tensor(
+        [i in used_set for i in range(target_vocab_size)],
+        dtype=torch.bool,  # must match register_buffer dtype in Eagle3LlamaForCausalLM
+    )
+
+    assert d2t.shape == (draft_vocab_size,), f"d2t shape {d2t.shape} != ({draft_vocab_size},)"
+    assert t2d.shape == (target_vocab_size,), f"t2d shape {t2d.shape} != ({target_vocab_size},)"
+    assert t2d.sum().item() == draft_vocab_size, (
+        f"t2d has {t2d.sum().item()} True entries, expected {draft_vocab_size}"
+    )
 
     return d2t, t2d
 

--- a/angelslim/compressor/speculative/train/data/data_utils.py
+++ b/angelslim/compressor/speculative/train/data/data_utils.py
@@ -145,9 +145,9 @@ def process_token_dict_to_mappings(
 
     assert d2t.shape == (draft_vocab_size,), f"d2t shape {d2t.shape} != ({draft_vocab_size},)"
     assert t2d.shape == (target_vocab_size,), f"t2d shape {t2d.shape} != ({target_vocab_size},)"
-    assert t2d.sum().item() == draft_vocab_size, (
-        f"t2d has {t2d.sum().item()} True entries, expected {draft_vocab_size}"
-    )
+    assert (
+        t2d.sum().item() == draft_vocab_size
+    ), f"t2d has {t2d.sum().item()} True entries, expected {draft_vocab_size}"
 
     return d2t, t2d
 


### PR DESCRIPTION
## Changes

Three improvements to `process_token_dict_to_mappings` in `data_utils.py`:

**Explicit dtypes on `d2t` and `t2d`**
`Eagle3LlamaForCausalLM` registers both tensors as buffers with `dtype=torch.int64` and `dtype=torch.bool`. Making this explicit at construction makes the contract visible and guards against platform edge cases.

**O(1) set membership for `t2d` construction**
`i in used_tokens` scans a list of `draft_vocab_size` elements for each of `target_vocab_size` iterations. Replacing with `used_set = set(used_tokens)` reduces this to O(target_vocab_size).

**Assertions after mapping construction**
Without post-construction checks, a bug in vocab padding or `most_common` logic produces silently wrong tensors that propagate into training buffers. Three assertions now catch shape and cardinality errors immediately.
