### PR TITLE
fix: dcut iframe 路径适配 readthedocs

### DIFF
--- a/docs/source/features/speculative_decoding/dcut.md
+++ b/docs/source/features/speculative_decoding/dcut.md
@@ -1,5 +1,3 @@
 # D-Cut
 
-```{raw} html
-<iframe src="/dcut.html" style="width:100%; height:80vh; border:none;"></iframe>
-```
+<iframe src="../../dcut.html" style="width:100%; height:80vh; border:none;"></iframe>


### PR DESCRIPTION
## 问题

D-Cut wrapper 页面的 iframe 使用绝对路径 `/dcut.html`，在 readthedocs 上会解析到域名根目录 (`angelslim.readthedocs.io/dcut.html`)，而实际文件在 `/zh-cn/latest/dcut.html`，导致 iframe 内容加载失败。

## 修复

改为相对路径 `../../dcut.html`，本地和 readthedocs 均可正确解析。