### PR TITLE
feat(ptq): add SmoothQuant calibration with vLLM & offline weight transform

### DIFF
--- a/angelslim/compressor/quant/core/vllm_calibrate_utils/__init__.py
+++ b/angelslim/compressor/quant/core/vllm_calibrate_utils/__init__.py
@@ -42,6 +42,15 @@ from .hooks import (
     setup_kvcache_perhead_hooks,
     setup_kvcache_pertensor_hooks,
     setup_mtp_activation_hooks,
+    # Smooth stats
+    SmoothAttnHook,
+    SmoothDownProjInputHook,
+    collect_fused_moe_smooth_stats,
+    get_smooth_stats,
+    print_smooth_stats,
+    set_percentile_subsample,
+    get_percentile_subsample,
+    setup_smooth_hooks,
 )
 from .search import (
     KVCachePerHeadValueHook,
@@ -54,6 +63,13 @@ from .search import (
     remove_kvcache_perhead_value_hooks,
     setup_kvcache_perhead_value_hooks,
     setup_kvcache_value_hooks,
+    # Smooth alpha search
+    SmoothAlphaSearchConfig,
+    SmoothAlphaSearcher,
+    SmoothAlphaValueHook,
+    collect_fused_moe_alpha_search_values,
+    remove_smooth_alpha_search_hooks,
+    setup_smooth_alpha_search_hooks,
 )
 
 __all__ = [
@@ -96,4 +112,20 @@ __all__ = [
     "remove_kvcache_perhead_value_hooks",
     "KVScaleSearcherPerHead",
     "get_kv_scale_search_results_perhead",
+    # Smooth stats
+    "SmoothAttnHook",
+    "SmoothDownProjInputHook",
+    "setup_smooth_hooks",
+    "get_smooth_stats",
+    "print_smooth_stats",
+    "collect_fused_moe_smooth_stats",
+    "set_percentile_subsample",
+    "get_percentile_subsample",
+    # Smooth alpha search
+    "SmoothAlphaSearchConfig",
+    "SmoothAlphaValueHook",
+    "SmoothAlphaSearcher",
+    "setup_smooth_alpha_search_hooks",
+    "remove_smooth_alpha_search_hooks",
+    "collect_fused_moe_alpha_search_values",
 ]

--- a/angelslim/compressor/quant/core/vllm_calibrate_utils/hooks.py
+++ b/angelslim/compressor/quant/core/vllm_calibrate_utils/hooks.py
@@ -15,7 +15,6 @@ the public ``setup_*`` / ``get_*`` / ``print_*`` / ``remove_*`` entry points.
 """
 
 import os
-
 import torch
 
 from ._common import (
@@ -57,6 +56,15 @@ __all__ = [
     "print_mtp_activation_stats",
     "get_mtp_moe_stats",
     "print_mtp_moe_stats",
+    # Smooth stats hooks
+    "SmoothAttnHook",
+    "SmoothDownProjInputHook",
+    "setup_smooth_hooks",
+    "get_smooth_stats",
+    "print_smooth_stats",
+    "collect_fused_moe_smooth_stats",
+    "set_percentile_subsample",
+    "get_percentile_subsample",
 ]
 
 
@@ -232,10 +240,6 @@ def setup_activation_hooks(model, kv_granularity="per-tensor"):
                 if hasattr(layer, "w13_weight") and layer.w13_weight is not None:
                     layer.w13_weight._vllm_layer_name = name
                     layer.w13_weight._moe_activation_stats_of_model = model._moe_activation_stats
-                    print(
-                        f"[DEBUG] Set w13_weight._vllm_layer_name = {name}, "
-                        f"type={type(layer.w13_weight)}"
-                    )
                 else:
                     print(
                         f"[DEBUG] Cannot set w13_weight._vllm_layer_name: "
@@ -1345,3 +1349,749 @@ def print_mtp_moe_stats(draft_model, verbose=False):
         print("[MTP] No MoE activation statistics available")
         return
     print_moe_stats(draft_model, verbose=verbose)
+
+
+# =============================================================================
+# Smooth Stats Hooks + Alpha Search
+# =============================================================================
+
+_SAMPLE_STRIDE = 683
+# Minimum samples we want to keep after stride-sampling.
+# numel <= _SAMPLE_STRIDE * _SAMPLE_MIN_KEEP → skip sampling (use full tensor).
+_SAMPLE_MIN_KEEP = 1024
+
+# --------------------------------------------------------------------------
+# External flag: enable / disable stride sub-sampling in percentile estimation.
+#
+# Three ways to control (in priority order at call-time):
+#   1. Python:   set_percentile_subsample(True / False)
+#                -- or --
+#                import vllm_calibrate_utils as U; U._SAMPLE_ENABLE = True
+#   2. Env var:  VLLM_CALIB_PERCENTILE_SUBSAMPLE=1   (enable)
+#                VLLM_CALIB_PERCENTILE_SUBSAMPLE=0   (disable)
+#                Read once at import time. Change via setter afterwards.
+#   3. Default:  True (sub-sampling ON — the fast path).
+#
+# Turn OFF when you need bit-exact percentile values and can pay the time;
+# turn ON (default) for ~stride-fold speed-up on large activations.
+# --------------------------------------------------------------------------
+_SAMPLE_ENABLE = os.getenv("VLLM_CALIB_PERCENTILE_SUBSAMPLE", "0") == "1"
+
+# --------------------------------------------------------------------------
+# Module-level cache for VLLM_MOE_COLLECT_SMOOTH_STATS flag.
+# collect_fused_moe_smooth_stats() is called from inside the vLLM FusedMoE
+# kernel on every forward pass (hot path), so we avoid os.getenv() overhead
+# by caching the flag here.  setup_smooth_hooks() updates this cache via
+# _set_moe_collect_smooth() when it enables collection at runtime.
+# --------------------------------------------------------------------------
+_MOE_COLLECT_SMOOTH = os.getenv("VLLM_MOE_COLLECT_SMOOTH_STATS", "0") == "1"
+
+
+def _set_moe_collect_smooth(enable: bool) -> None:
+    """Update the module-level MoE smooth-stats collection flag.
+
+    Called by :func:`setup_smooth_hooks` when it sets the env var at runtime,
+    so that :func:`collect_fused_moe_smooth_stats` (hot path) can skip the
+    ``os.getenv`` call and read the cached value instead.
+    """
+    global _MOE_COLLECT_SMOOTH
+    _MOE_COLLECT_SMOOTH = bool(enable)
+
+def set_percentile_subsample(enable: bool) -> None:
+    """Enable or disable stride sub-sampling for percentile estimation.
+
+    Affects :meth:`ActivationHook._percentile_min_max` and
+    :func:`_per_channel_absmax`. Takes effect on the next hook invocation
+    (safe to call between calibration batches).
+
+    Args:
+        enable: True to sub-sample (fast), False to use the full tensor (slow
+            but exact).
+    """
+    global _SAMPLE_ENABLE
+    _SAMPLE_ENABLE = bool(enable)
+
+
+def get_percentile_subsample() -> bool:
+    """Return the current sub-sampling flag."""
+    return _SAMPLE_ENABLE
+
+def _per_channel_absmax(tensor: torch.Tensor, token_clip: float = -1.0) -> torch.Tensor:
+    """Per-channel absmax over dim=0, with optional percentile clipping.
+
+    Args:
+        tensor: shape [num_tokens, dim] (1-D input is first unsqueezed to 2-D).
+        token_clip: clip mode for the per-channel statistic.
+            - <= 0 (default): return the absolute max of |tensor| along dim=0.
+            - In (0, 1]: treated as a quantile fraction (e.g. 0.999).
+            - In (1, 100): treated as a percentile value (e.g. 99.9).
+            When a percentile is given, return the q-th percentile of |tensor|
+            along dim=0 per channel. This suppresses outlier tokens while still
+            producing a per-channel [dim] vector compatible with SmoothQuant
+            scale calibration.
+
+    Implementation notes:
+        * Uses ``torch.topk(..., dim=0)`` instead of ``torch.kthvalue`` — much
+          faster on GPU when k is small (which is always true for tail
+          percentiles like 0.999).
+        * Sub-samples rows with a coprime stride (``_SAMPLE_STRIDE`` = 683)
+          when ``num_tokens`` is large. 683 is prime and coprime with all
+          common hidden_dims, so sampling is uniform across channels.
+        * Returns a CPU tensor to stay compatible with existing callers that
+          ``torch.maximum`` against CPU-resident running stats.
+
+    Returns:
+        CPU tensor of shape [dim].
+    """
+    if tensor.dim() == 1:
+        tensor = tensor.unsqueeze(0)
+    abs_t = tensor.abs()
+
+    use_percentile = token_clip is not None and token_clip > 0
+    if not use_percentile:
+        return abs_t.max(dim=0).values.detach().cpu()
+
+    num_tokens = abs_t.shape[0]
+    if num_tokens == 0:
+        return abs_t.max(dim=0).values.detach().cpu()
+
+    # Normalise token_clip to a quantile fraction in (0, 1].
+    tc = float(token_clip)
+    q = tc if tc <= 1.0 else tc / 100.0
+    # Clamp to a sensible range to avoid degenerate indices.
+    q = max(0.5, min(q, 1.0 - 1e-6))
+
+    # topk requires a floating dtype; cast if needed.
+    if not abs_t.is_floating_point():
+        abs_t = abs_t.float()
+
+    # Stride-sample rows for very large token counts. Gated by the
+    # module-level flag (see set_percentile_subsample).
+    if _SAMPLE_ENABLE and num_tokens > _SAMPLE_STRIDE * _SAMPLE_MIN_KEEP:
+        abs_t = abs_t[::_SAMPLE_STRIDE]
+        num_tokens = abs_t.shape[0]
+
+    try:
+        # Short-circuit when the clipped tail is < 1 token per channel:
+        # topk(k=1, dim=0).values.min(0) == max(0), but plain reduction is
+        # much cheaper on GPU (no topk workspace / merge), so skip topk.
+        k_high_raw = int(round((1.0 - q) * num_tokens))
+        if k_high_raw <= 1:
+            return abs_t.max(dim=0).values.detach().cpu()
+
+        # topk along dim=0 takes the k_high largest per channel;
+        # the min of those k_high values ≈ q-th quantile of |x| per channel.
+        k_high = min(num_tokens, k_high_raw)
+        top = torch.topk(abs_t, k_high, dim=0, largest=True, sorted=False).values  # [k_high, dim]
+        return top.min(dim=0).values.detach().cpu()
+    except Exception as e:  # pragma: no cover - defensive fallback
+        print(
+            f"[_per_channel_absmax] token_clip topk failed (shape="
+            f"{tuple(abs_t.shape)}, q={q}): {e}. Fallback to absolute max."
+        )
+        return abs_t.max(dim=0).values.detach().cpu()
+
+
+class SmoothAttnHook:
+    """
+    Hook for collecting per-channel (last-dim) absmax and EMA statistics on:
+      - q, k inputs  to vllm.attention.layer.Attention (post-RoPE)
+      - attn output  from vllm.attention.layer.Attention
+        (= o_proj input, shape [num_tokens, num_heads * head_dim])
+
+    v is intentionally skipped.
+
+    EMA update rule:  ema = ema_momentum * ema + (1 - ema_momentum) * current_absmax
+
+    Args:
+        layer_name: Attention layer name.
+        smooth_stats: Shared dict that stores per-key running absmax/ema.
+        ema_momentum: EMA decay factor.
+        token_clip: Optional percentile-based clipping for the per-channel
+            absmax. See :func:`_per_channel_absmax` for the accepted values.
+            <=0 (default) preserves the original absolute-max behaviour.
+    """
+
+    def __init__(self, layer_name, smooth_stats, ema_momentum=0.9, token_clip=-1):
+        self.layer_name = layer_name
+        self.smooth_stats = smooth_stats
+        self.ema_momentum = ema_momentum
+        self.token_clip = token_clip
+        self.call_count = 0
+
+    def _update(self, key, tensor):
+        """Update absmax and EMA for a named tensor slot."""
+        with torch.no_grad():
+            # tensor: [num_tokens, dim]  (vLLM flattens batch into tokens)
+            # per-channel absmax (or percentile when token_clip>0) over tokens
+            cur_absmax = _per_channel_absmax(tensor, token_clip=self.token_clip)  # [dim]
+
+            stats = self.smooth_stats[key]
+            # absmax: running maximum
+            if stats["absmax"] is None:
+                stats["absmax"] = cur_absmax
+            else:
+                stats["absmax"] = torch.maximum(stats["absmax"], cur_absmax)
+            # ema: exponential moving average of per-channel absmax
+            if stats["ema"] is None:
+                stats["ema"] = cur_absmax.clone()
+            else:
+                stats["ema"] = (
+                    self.ema_momentum * stats["ema"]
+                    + (1.0 - self.ema_momentum) * cur_absmax
+                )
+            stats["call_count"] = self.call_count
+
+    def __call__(self, module, input, output):
+        self.call_count += 1
+        # --- inputs: q, k (v skipped) ---
+        q = input[0] if len(input) > 0 else None
+        k = input[1] if len(input) > 1 else None
+        for tag, tensor in [("q", q), ("k", k)]:
+            if tensor is not None and isinstance(tensor, torch.Tensor):
+                self._update(f"{self.layer_name}.{tag}", tensor)
+        # --- output: attention result = o_proj input ---
+        attn_out = output[0] if isinstance(output, tuple) else output
+        if attn_out is not None and isinstance(attn_out, torch.Tensor):
+            self._update(f"{self.layer_name}.attn_out", attn_out)
+
+
+class SmoothDownProjInputHook:
+    """
+    Hook for collecting per-channel (last-dim) absmax and EMA statistics
+    on the INPUT of the MLP down_proj layer.
+
+    This captures silu(gate) * up, which is the true activation that
+    down_proj sees — the correct signal for SmoothQuant scale calibration.
+
+    Input shape: [num_tokens, intermediate_size]
+
+    EMA update rule:  ema = ema_momentum * ema + (1 - ema_momentum) * current_absmax
+
+    Args:
+        layer_name: down_proj layer name.
+        smooth_stats: Shared dict that stores per-layer running absmax/ema.
+        ema_momentum: EMA decay factor.
+        token_clip: Optional percentile-based clipping for the per-channel
+            absmax. See :func:`_per_channel_absmax` for the accepted values.
+            <=0 (default) preserves the original absolute-max behaviour.
+    """
+
+    def __init__(self, layer_name, smooth_stats, ema_momentum=0.9, token_clip=-1):
+        self.layer_name = layer_name
+        self.smooth_stats = smooth_stats
+        self.ema_momentum = ema_momentum
+        self.token_clip = token_clip
+        self.call_count = 0
+
+    def __call__(self, module, input, output):
+        self.call_count += 1
+        # input to down_proj is a tuple; first element is the activation tensor
+        act = input[0] if isinstance(input, tuple) else input
+        if not isinstance(act, torch.Tensor):
+            return
+
+        with torch.no_grad():
+            # per-channel absmax (or percentile when token_clip>0): [intermediate_size]
+            cur_absmax = _per_channel_absmax(act, token_clip=self.token_clip)
+
+            stats = self.smooth_stats[self.layer_name]
+            if stats["absmax"] is None:
+                stats["absmax"] = cur_absmax
+            else:
+                stats["absmax"] = torch.maximum(stats["absmax"], cur_absmax)
+            if stats["ema"] is None:
+                stats["ema"] = cur_absmax.clone()
+            else:
+                stats["ema"] = (
+                    self.ema_momentum * stats["ema"]
+                    + (1.0 - self.ema_momentum) * cur_absmax
+                )
+            stats["call_count"] = self.call_count
+
+
+def setup_smooth_hooks(
+    model,
+    ema_momentum=0.9,
+    collect_attn=True,
+    collect_down_proj=True,
+    collect_moe=True,
+    token_clip=-1,
+):
+    """
+    Register smooth hooks on the model to collect per-channel absmax and EMA stats.
+
+    Args:
+        model: The nn.Module model instance (called inside llm.apply_model).
+        ema_momentum: EMA decay factor (default 0.9).
+        collect_attn: If True, register hooks on vllm.attention.layer.Attention to
+                      collect q / k inputs and attn output (= o_proj input).
+        collect_down_proj: If True, register hooks on dense MLP down_proj layers to
+                           collect silu(gate)*up (the true down_proj input).
+        collect_moe: If True, wire FusedMoE layers for kernel-injected smooth stats.
+                     Requires VLLM_MOE_COLLECT_SMOOTH_STATS=1 env var AND the
+                     corresponding call to collect_fused_moe_smooth_stats() inside
+                     the vLLM FusedMoE kernel source.
+        token_clip: Optional percentile-based clipping for per-channel absmax
+                    collection in SmoothAttnHook / SmoothDownProjInputHook.
+                    - <= 0 (default): disabled, use absolute max (original behaviour).
+                    - In (0, 1]: quantile fraction (e.g. 0.999).
+                    - In (1, 100): percentile value (e.g. 99.9).
+                    A high percentile suppresses outlier tokens during calibration.
+                    Does NOT affect MoE kernel-injected stats (those go through
+                    collect_fused_moe_smooth_stats and are unchanged).
+
+    Statistics are stored in model._smooth_stats:
+      {
+        "<attn_layer>.q":        {"absmax": Tensor, "ema": Tensor, "call_count": int},
+        "<attn_layer>.k":        {...},
+        "<attn_layer>.attn_out": {...},   # = o_proj input
+        "<down_proj_layer>":     {"absmax": Tensor, "ema": Tensor, "call_count": int},
+        "<moe_layer>.down_proj": {"absmax": Tensor, "ema": Tensor, "call_count": int},
+      }
+
+    Returns a summary string (compatible with llm.apply_model return protocol).
+    """
+    try:
+        # vLLM ≥ 0.20 (Tencent custom): Attention moved under model_executor.
+        from vllm.model_executor.layers.attention import Attention
+    except ImportError:
+        # Older vLLM layout.
+        from vllm.attention.layer import Attention
+    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+    from vllm.model_executor.layers.linear import LinearBase
+
+    # ------------------------------------------------------------------
+    # 1. Discover layers for each requested scope
+    # ------------------------------------------------------------------
+    attn_layers       = _find_layers(model, layers=[Attention])      if collect_attn      else {}
+    down_proj_layers  = {}
+    if collect_down_proj:
+        all_linear = _find_layers(model, layers=[torch.nn.Linear, LinearBase])
+        down_proj_layers = {
+            name: module
+            for name, module in all_linear.items()
+            if name.split(".")[-1] == "down_proj"
+        }
+    moe_layers = _find_layers(model, layers=[FusedMoE]) if collect_moe else {}
+
+    # ------------------------------------------------------------------
+    # EP (Expert Parallelism) check: smooth stat collection is NOT
+    # compatible with EP because each rank only holds a subset of experts,
+    # so per-channel stats are gathered over different token sets on
+    # different ranks.  all_gather in get_smooth_stats only handles the
+    # TP intermediate-size shard dimension; it cannot reconstruct stats
+    # that are split by expert assignment.  Abort early to prevent silent
+    # wrong results.
+    # ------------------------------------------------------------------
+    if collect_moe and moe_layers:
+        os.environ["VLLM_MOE_COLLECT_SMOOTH_STATS"] = "1"
+        _set_moe_collect_smooth(True)   # keep module-level cache in sync
+        ep_layers = {
+            name: layer
+            for name, layer in moe_layers.items()
+            if getattr(layer, "use_ep", False) and getattr(layer, "ep_size", 1) > 1
+        }
+        if ep_layers:
+            ep_example = next(iter(ep_layers))
+            ep_size = getattr(ep_layers[ep_example], "ep_size", "?")
+            raise RuntimeError(
+                f"[setup_smooth_hooks] Expert Parallelism (EP) is NOT supported for "
+                f"smooth stat calibration. Detected {len(ep_layers)} FusedMoE layer(s) "
+                f"with ep_size={ep_size} (e.g. '{ep_example}'). "
+                f"Please re-run calibration with pure TP (set ep_size=1 / "
+                f"disable expert parallelism)."
+            )
+
+    collect_moe_smooth = collect_moe and os.getenv("VLLM_MOE_COLLECT_SMOOTH_STATS", "0") == "1"
+
+    print(
+        f"---------Smooth hooks scope: "
+        f"attn={'ON' if collect_attn else 'OFF'} ({len(attn_layers)} layers), "
+        f"down_proj={'ON' if collect_down_proj else 'OFF'} ({len(down_proj_layers)} layers), "
+        f"moe={'ON' if collect_moe else 'OFF'} ({len(moe_layers)} layers, "
+        f"kernel_inject={'ON' if collect_moe_smooth else 'OFF'})---------"
+    )
+    if collect_moe and moe_layers and not collect_moe_smooth:
+        print(
+            "---------[WARNING] MoE scope enabled but VLLM_MOE_COLLECT_SMOOTH_STATS"
+            " is not set to 1 — MoE stats will NOT be collected---------"
+        )
+
+    # ------------------------------------------------------------------
+    # 2. Initialise stats storage
+    # ------------------------------------------------------------------
+    if not hasattr(model, "_smooth_stats"):
+        model._smooth_stats = {}
+    # Metadata dict: key → gather strategy info
+    # Used by get_smooth_stats to handle GQA + TP correctly.
+    if not hasattr(model, "_smooth_stats_meta"):
+        model._smooth_stats_meta = {}
+
+    for name, attn_module in attn_layers.items():
+        # Try to read kv_head replica count from the qkv_proj inside the
+        # parent LlamaAttention (or equivalent). The Attention module itself
+        # doesn't hold this, but its sibling qkv_proj does.
+        # We walk up one level to find it.
+        kv_replicas = 1
+        try:
+            from vllm.model_executor.layers.linear import QKVParallelLinear
+            parent_name = ".".join(name.split(".")[:-1])  # drop ".attn" suffix
+            parent = model
+            for part in parent_name.split("."):
+                parent = getattr(parent, part)
+            qkv_proj = getattr(parent, "qkv_proj", None)
+            if isinstance(qkv_proj, QKVParallelLinear):
+                kv_replicas = qkv_proj.num_kv_head_replicas
+        except Exception:
+            pass
+
+        for tag in ("q", "k", "attn_out"):
+            key = f"{name}.{tag}"
+            if key not in model._smooth_stats:
+                model._smooth_stats[key] = {"absmax": None, "ema": None, "call_count": 0}
+            # k (and v if we ever add it) may have replicas across TP ranks
+            model._smooth_stats_meta[key] = {
+                "kv_replicas": kv_replicas if tag == "k" else 1,
+            }
+
+    for name in down_proj_layers:
+        if name not in model._smooth_stats:
+            model._smooth_stats[name] = {"absmax": None, "ema": None, "call_count": 0}
+
+    if collect_moe_smooth:
+        for name, layer in moe_layers.items():
+            num_experts = getattr(layer, "global_num_experts", None) or getattr(layer, "local_num_experts", None)
+            if num_experts is None:
+                print(f"[WARNING] Cannot determine num_experts for {name}, skipping pre-allocation")
+                continue
+            for expert_id in range(num_experts):
+                key = f"{name}.{expert_id}.down_proj"
+                if key not in model._smooth_stats:
+                    model._smooth_stats[key] = {"absmax": None, "ema": None, "call_count": 0}
+
+    # ------------------------------------------------------------------
+    # 3. Register PyTorch forward hooks (idempotent guard)
+    # ------------------------------------------------------------------
+    if not hasattr(model, "_smooth_hooks"):
+        model._smooth_hooks = []
+
+        for name, layer in attn_layers.items():
+            hook = SmoothAttnHook(
+                name,
+                model._smooth_stats,
+                ema_momentum=ema_momentum,
+                token_clip=token_clip,
+            )
+            handle = layer.register_forward_hook(hook)
+            model._smooth_hooks.append(handle)
+
+        for name, layer in down_proj_layers.items():
+            hook = SmoothDownProjInputHook(
+                name,
+                model._smooth_stats,
+                ema_momentum=ema_momentum,
+                token_clip=token_clip,
+            )
+            handle = layer.register_forward_hook(hook)
+            model._smooth_hooks.append(handle)
+
+    # ------------------------------------------------------------------
+    # 4. Wire FusedMoE layers for kernel-injected smooth stats
+    # ------------------------------------------------------------------
+    if collect_moe_smooth:
+        for name, layer in moe_layers.items():
+            if hasattr(layer, "w13_weight") and layer.w13_weight is not None:
+                layer.w13_weight._vllm_layer_name_smooth = name
+                layer.w13_weight._smooth_stats_of_model = model._smooth_stats
+                layer.w13_weight._smooth_ema_momentum = ema_momentum
+                # print(f"[DEBUG] Set w13_weight._vllm_layer_name_smooth = {name}")
+            else:
+                print(
+                    f"[DEBUG] Cannot set smooth attrs on w13_weight for {name}: "
+                    f"hasattr={hasattr(layer, 'w13_weight')}, "
+                    f"is_none={getattr(layer, 'w13_weight', None) is None}"
+                )
+
+    print(f"---------Smooth hooks registered: {len(model._smooth_hooks)} total---------")
+    return f"Registered {len(model._smooth_hooks)} smooth hooks"
+
+
+def get_smooth_stats(model):
+    """
+    Retrieve smooth statistics from the model.
+    Performs all-reduce (MAX for absmax, mean for ema) across all workers.
+
+    Returns a serialisable dict:
+      {
+        "<key>": {"absmax": [float, ...], "ema": [float, ...]},
+        ...
+      }
+
+    TP-aware gather (unchanged semantics):
+        Each rank holds one shard of the full channel dimension.
+        For k under GQA+TP (kv_replicas > 1), only every kv_replicas-th
+        rank carries a unique shard — the rest are duplicates and are skipped.
+        setup_smooth_hooks() raises RuntimeError for EP, so EP never reaches here.
+
+    Performance optimisation over the naïve per-key loop:
+        The original implementation issued one ``dist.all_gather`` call per key
+        for absmax and one for ema, resulting in O(N) collective round-trips
+        (N = number of stat keys).  For a large MoE model this can be thousands
+        of calls (e.g. 60 layers × 64 experts = 3 840 expert keys alone), each
+        paying the fixed NCCL launch latency.
+
+        The optimised version groups keys by ``(tensor_size, kv_replicas)``.
+        Keys in the same group are stacked into a 2-D tensor and gathered in
+        **one** ``dist.all_gather`` call.  The whole-group result is moved to CPU
+        in a single transfer.  Typical groups for a Transformer model:
+          • (hidden_dim // TP, 1)              — q, attn_out, dense down_proj
+          • (kv_head_dim // TP, kv_replicas)   — k (GQA)
+          • (intermediate_dim // TP, 1)        — all MoE expert down_proj keys
+        → 2–4 ``all_gather`` calls total, regardless of layer / expert count.
+        This reduces wall-clock time from O(N) collective round-trips to O(S)
+        where S ≪ N (typically minutes → seconds on large MoE models).
+    """
+    if not hasattr(model, "_smooth_stats"):
+        return None
+
+    import torch.distributed as dist
+    from collections import defaultdict
+
+    rank, world_size = _get_dist_info()
+
+    # ------------------------------------------------------------------
+    # TP-aware gather: each rank holds a shard of the full channel dim.
+    #
+    # For q / attn_out / down_proj / MoE (pure TP only):
+    #   Each rank has a *unique* shard → all_gather + cat gives full dim.
+    #
+    # NOTE: EP (Expert Parallelism) is NOT supported here.  With EP each
+    # rank owns a different subset of experts and processes different
+    # tokens, so a simple all_gather + cat would produce wrong channel
+    # ordering / shape.  setup_smooth_hooks() already raises RuntimeError
+    # when EP is detected, so we should never reach this point with EP.
+    #
+    # For k (GQA + TP where tp > kv_heads):
+    #   num_kv_head_replicas > 1, meaning consecutive ranks share the *same*
+    #   kv head shard. e.g. tp=16, kv_heads=8 → replicas=2, so rank0 and
+    #   rank1 both hold kv_head_0; rank2 and rank3 hold kv_head_1; etc.
+    #   We must only collect one copy per unique shard, i.e. every
+    #   `kv_replicas`-th rank, to avoid duplicating channels.
+    # ------------------------------------------------------------------
+    if world_size > 1 and dist.is_initialized():
+        meta = getattr(model, "_smooth_stats_meta", {})
+
+        # --------------------------------------------------------------
+        # Batched all_gather: group keys by (tensor_size, kv_replicas)
+        # so that each group needs only ONE all_gather call.
+        #
+        # Typical groups for a Transformer model (2-4 total):
+        #   (hidden_dim // TP, 1)            — q, attn_out, dense down_proj
+        #   (kv_head_dim // TP, kv_replicas) — k (GQA)
+        #   (intermediate_dim // TP, 1)      — all MoE expert down_proj
+        # This reduces O(N) NCCL round-trips to O(S) where S ≪ N.
+        # --------------------------------------------------------------
+
+        # Step 1: group keys by (tensor_size, kv_replicas)
+        groups = defaultdict(list)  # (size, kv_reps) -> [(key, has_ema), ...]
+        for key, stats in model._smooth_stats.items():
+            if stats["absmax"] is None:
+                continue
+            kv_replicas = meta.get(key, {}).get("kv_replicas", 1)
+            size = stats["absmax"].shape[0]
+            has_ema = stats["ema"] is not None
+            groups[(size, kv_replicas)].append((key, has_ema))
+
+        # Step 2: per-group batched all_gather
+        for (size, kv_replicas), keys_info in groups.items():
+            # Build a stacked 2-D tensor: each key contributes 1 row
+            # (absmax) or 2 rows (absmax + ema).
+            rows = []
+            row_map = []  # tracks (key, field) for each row
+            for key, has_ema in keys_info:
+                rows.append(model._smooth_stats[key]["absmax"])
+                row_map.append((key, "absmax"))
+                if has_ema:
+                    rows.append(model._smooth_stats[key]["ema"])
+                    row_map.append((key, "ema"))
+
+            # Single H2D transfer for the whole group
+            stacked = torch.stack(rows, dim=0).cuda()  # [num_rows, size]
+
+            # Single buffer allocation for the whole group
+            gathered = [torch.zeros_like(stacked) for _ in range(world_size)]
+
+            # ★ ONE all_gather for the entire group ★
+            dist.all_gather(gathered, stacked)
+
+            # De-duplicate replicated shards (GQA k heads)
+            unique = gathered[::kv_replicas]  # list of [num_rows, size]
+
+            # Single D2H transfer: concat along channel dim, move to CPU
+            full = torch.cat(unique, dim=1).cpu()  # [num_rows, full_size]
+
+            # Scatter results back to individual stats entries
+            for i, (key, field) in enumerate(row_map):
+                model._smooth_stats[key][field] = full[i]
+
+            del stacked, gathered, full
+
+    # ------------------------------------------------------------------
+    # Serialise to plain Python lists (JSON-friendly)
+    # ------------------------------------------------------------------
+    result = {}
+    for key, stats in model._smooth_stats.items():
+        result[key] = {
+            "absmax": stats["absmax"].tolist() if stats["absmax"] is not None else None,
+            "ema":    stats["ema"].tolist()    if stats["ema"]    is not None else None,
+            "call_count": stats.get("call_count", 0),
+        }
+    return result
+
+
+def print_smooth_stats(model, max_rows=20):
+    """
+    Pretty-print smooth statistics (per-channel absmax/ema summary).
+    Only prints on rank 0.
+    """
+    if not hasattr(model, "_smooth_stats"):
+        print("No smooth statistics available")
+        return
+
+    rank, _ = _get_dist_info()
+    if rank != 0:
+        return
+
+    print("\n" + "=" * 90)
+    print("Smooth Statistics  (per-channel absmax / ema — showing scalar max over channels)")
+    print("=" * 90)
+    rows = 0
+    for key, stats in model._smooth_stats.items():
+        if stats["absmax"] is None:
+            absmax_repr = "N/A"
+            ema_repr = "N/A"
+        else:
+            absmax_repr = f"{stats['absmax'].max().item():.6f}"
+            ema_repr    = (
+                f"{stats['ema'].max().item():.6f}"
+                if stats["ema"] is not None
+                else "N/A"
+            )
+        print(
+            f"{key:70s} | absmax_max: {absmax_repr:>12} | ema_max: {ema_repr:>12}"
+            f" | calls: {stats.get('call_count', 0):4d}"
+        )
+        rows += 1
+        if rows >= max_rows:
+            remaining = len(model._smooth_stats) - max_rows
+            if remaining > 0:
+                print(f"  ... and {remaining} more entries (use get_smooth_stats() for full data)")
+            break
+    print("=" * 90 + "\n")
+
+
+def collect_fused_moe_smooth_stats(
+    stage,
+    hidden_states,
+    topk_ids,
+    layer_name=None,
+    global_smooth_stats=None,
+    ema_momentum=0.9,
+):
+    """
+    Collect per-channel absmax and EMA statistics for FusedMoE internal activations.
+    Mirrors collect_fused_moe_internal_stats but records per-channel vectors instead of
+    scalar min/max, for use with SmoothQuant scale calibration.
+
+    Must be called from within the vLLM FusedMoE kernel (requires vLLM source modification),
+    at the point where hidden_states is the input to w2 (down_proj), i.e. after
+    gate_up matmul + silu activation.
+
+    Args:
+        stage: "down_proj" (gate_up stage is not used for smooth, only down_proj input)
+        hidden_states: Input tensor to down_proj, shape [num_tokens * top_k, intermediate_size]
+        topk_ids: Expert assignment tensor [num_tokens, top_k], used to filter out padding
+                  tokens (expert_id == -1) introduced by variable top_k / expert parallelism.
+        layer_name: FusedMoE layer name (passed via w13_weight._vllm_layer_name_smooth)
+        global_smooth_stats: The model._smooth_stats dict
+                             (passed via w13_weight._smooth_stats_of_model)
+        ema_momentum: EMA decay factor (passed via w13_weight._smooth_ema_momentum)
+
+    """
+    if global_smooth_stats is None or layer_name is None:
+        return
+    if stage != "down_proj":
+        return  # Only down_proj input is needed for smooth stats
+
+    with torch.no_grad():
+        act = hidden_states
+        if act.dim() == 1:
+            act = act.unsqueeze(0)
+
+        # Resolve flat_expert_ids and flat_hidden.
+        # hidden_states shape: [num_tokens * top_k, intermediate_size]
+        # topk_ids shape:      [num_tokens, top_k]
+        num_tokens_hs = act.shape[0]
+        num_tokens_topk = topk_ids.shape[0]
+        top_k = topk_ids.shape[1]
+
+        if num_tokens_hs == num_tokens_topk * top_k:
+            flat_expert_ids = topk_ids.reshape(-1)   # [num_tokens * top_k]
+        else:
+            # Shape mismatch — fall back to layer-level (no per-expert breakdown)
+            flat_expert_ids = None
+
+        if flat_expert_ids is not None:
+            # --- Per-expert stats ---
+            unique_experts = flat_expert_ids.unique()
+            for expert_id_tensor in unique_experts:
+                expert_id = expert_id_tensor.item()
+                if expert_id < 0:
+                    continue  # Skip padding tokens (expert_id == -1)
+                expert_key = f"{layer_name}.{expert_id}.down_proj"
+                # Dynamically create entry if not pre-allocated
+                if expert_key not in global_smooth_stats:
+                    global_smooth_stats[expert_key] = {"absmax": None, "ema": None, "call_count": 0}
+                mask = flat_expert_ids == expert_id_tensor
+                expert_hidden = act[mask]
+                if expert_hidden.numel() == 0:
+                    continue
+                cur_absmax = expert_hidden.abs().max(dim=0).values.detach().cpu()
+                stats = global_smooth_stats[expert_key]
+                if stats["absmax"] is None:
+                    stats["absmax"] = cur_absmax
+                else:
+                    stats["absmax"] = torch.maximum(stats["absmax"], cur_absmax)
+                if stats["ema"] is None:
+                    stats["ema"] = cur_absmax.clone()
+                else:
+                    stats["ema"] = (
+                        ema_momentum * stats["ema"]
+                        + (1.0 - ema_momentum) * cur_absmax
+                    )
+                stats["call_count"] = stats.get("call_count", 0) + 1
+        else:
+            # Fallback: shape mismatch, collect layer-level stats without per-expert split
+            valid_act = act  # cannot filter without expert ids
+            if valid_act.numel() == 0:
+                return
+            fallback_key = f"{layer_name}.down_proj"
+            if fallback_key not in global_smooth_stats:
+                global_smooth_stats[fallback_key] = {"absmax": None, "ema": None, "call_count": 0}
+            cur_absmax = valid_act.abs().max(dim=0).values.detach().cpu()
+            stats = global_smooth_stats[fallback_key]
+            if stats["absmax"] is None:
+                stats["absmax"] = cur_absmax
+            else:
+                stats["absmax"] = torch.maximum(stats["absmax"], cur_absmax)
+            if stats["ema"] is None:
+                stats["ema"] = cur_absmax.clone()
+            else:
+                stats["ema"] = (
+                    ema_momentum * stats["ema"]
+                    + (1.0 - ema_momentum) * cur_absmax
+                )
+            stats["call_count"] = stats.get("call_count", 0) + 1
+
+

--- a/angelslim/compressor/quant/core/vllm_calibrate_utils/search.py
+++ b/angelslim/compressor/quant/core/vllm_calibrate_utils/search.py
@@ -31,6 +31,13 @@ __all__ = [
     "remove_kvcache_perhead_value_hooks",
     "KVScaleSearcherPerHead",
     "get_kv_scale_search_results_perhead",
+    # Smooth alpha search
+    "SmoothAlphaSearchConfig",
+    "SmoothAlphaValueHook",
+    "SmoothAlphaSearcher",
+    "setup_smooth_alpha_search_hooks",
+    "remove_smooth_alpha_search_hooks",
+    "collect_fused_moe_alpha_search_values",
 ]
 
 
@@ -749,3 +756,701 @@ def get_kv_scale_search_results_perhead(results_list: list) -> dict:
         final[stats_key] = [head_dict[i] for i in sorted_indices]
 
     return final
+
+
+
+# =============================================================================
+# Smooth Alpha Grid Search (down_proj only)
+# =============================================================================
+
+import os
+from dataclasses import dataclass
+
+@dataclass
+class SmoothAlphaSearchConfig:
+    """Configuration for smooth alpha grid search."""
+    alpha_min: float = 0.3
+    alpha_max: float = 1.0
+    alpha_steps: int = 8              # [0.3, 0.4, ..., 1.0]
+    act_quant_method: str = "per_token"       # "per_tensor" | "per_token"
+    act_quant_type: str = "int8"              # "int8" | "fp8"
+    weight_quant_method: str = "per_channel"  # "per_tensor" | "per_channel" | "per_group" | "per_block"
+    weight_quant_type: str = "int8"           # "int8" | "int4" | "fp8"
+    weight_quant_bits: int = 8
+    weight_group_size: int = 128              # per_group, -1 = per_channel
+    block_size: int = 128                     # per_block fp8
+    use_ema_for_absmax: bool = False
+    smooth_search_mode: str = "default"       # "default" | "per-tensor-act-first"
+    act_mul_min: float = 0.1                  # per-tensor-act-first: multiplier range min
+    act_mul_max: float = 1.0                  # per-tensor-act-first: multiplier range max
+    smooth_min: float = 1e-6             # per-tensor-act-first: smooth clamp lower bound
+    smooth_max: float = 1e6                   # per-tensor-act-first: smooth clamp upper bound
+
+
+# ---------------------------------------------------------------------------
+# QDQ helpers for grid search
+# ---------------------------------------------------------------------------
+
+def _smooth_qdq_act(
+    x: torch.Tensor,
+    method: str = "per_token",
+    quant_type: str = "int8",
+    bits: int = 8,
+) -> torch.Tensor:
+    """Quantize-dequantize activation (already divided by smooth_weight).
+
+    Args:
+        x: [N, in_features], float32
+        method: "per_tensor" | "per_token"
+        quant_type: "int8" | "fp8"
+        bits: bit width for INT
+    Returns:
+        x_qdq: [N, in_features], float32
+    """
+    if quant_type in ("int8", "int4", "int"):
+        bnt = (1 << (bits - 1)) - 1  # 127 for int8
+        if method == "per_tensor":
+            scale = x.abs().max().clamp(min=1e-8) / bnt
+        else:  # per_token
+            scale = x.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8) / bnt
+        return (x / scale).round().clamp(-bnt - 1, bnt) * scale
+
+    elif quant_type == "fp8":
+        fp8_max = torch.finfo(torch.float8_e4m3fn).max  # 448.0
+        if method == "per_tensor":
+            scale = x.abs().max().clamp(min=1e-8) / fp8_max
+        else:  # per_token
+            scale = x.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8) / fp8_max
+        q = (x / scale).clamp(-fp8_max, fp8_max).to(torch.float8_e4m3fn)
+        return q.float() * scale
+
+    else:
+        raise ValueError(f"Unknown act quant_type: {quant_type}")
+
+
+def _smooth_qdq_weight(
+    w: torch.Tensor,
+    method: str = "per_channel",
+    quant_type: str = "int8",
+    bits: int = 8,
+    group_size: int = 128,
+    block_size: int = 128,
+) -> torch.Tensor:
+    """Quantize-dequantize weight (already multiplied by smooth_weight).
+
+    Args:
+        w: [out_features, in_features], float32
+        method: "per_tensor" | "per_channel" | "per_group" | "per_block"
+        quant_type: "int8" | "int4" | "int" | "fp8"
+        bits: bit width for INT
+        group_size: for per_group (along dim=1)
+        block_size: for per_block fp8
+    Returns:
+        w_qdq: [out_features, in_features], float32
+    """
+    if quant_type in ("int8", "int4", "int"):
+        bnt = (1 << (bits - 1)) - 1
+
+        if method == "per_tensor":
+            scale = w.abs().max().clamp(min=1e-8) / bnt
+            return (w / scale).round().clamp(-bnt - 1, bnt) * scale
+
+        elif method == "per_channel":
+            # per output-channel (per row)
+            scale = w.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8) / bnt
+            return (w / scale).round().clamp(-bnt - 1, bnt) * scale
+
+        elif method == "per_group":
+            # group along in_features (dim=1)
+            out_feat, in_feat = w.shape
+            gs = group_size if group_size > 0 else in_feat
+            if in_feat % gs != 0:
+                # pad to group_size multiple
+                pad_len = gs - in_feat % gs
+                w_padded = torch.nn.functional.pad(w, (0, pad_len))
+            else:
+                w_padded = w
+                pad_len = 0
+            w_grouped = w_padded.reshape(out_feat, -1, gs)
+            scale = w_grouped.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8) / bnt
+            w_qdq = (w_grouped / scale).round().clamp(-bnt - 1, bnt) * scale
+            w_qdq = w_qdq.reshape(out_feat, -1)
+            if pad_len > 0:
+                w_qdq = w_qdq[:, :in_feat]
+            return w_qdq
+
+        else:
+            raise ValueError(f"Unknown weight method for INT: {method}")
+
+    elif quant_type == "fp8":
+        fp8_max = torch.finfo(torch.float8_e4m3fn).max
+
+        if method == "per_tensor":
+            scale = w.abs().max().clamp(min=1e-8) / fp8_max
+            q = (w / scale).clamp(-fp8_max, fp8_max).to(torch.float8_e4m3fn)
+            return q.float() * scale
+
+        elif method == "per_channel":
+            scale = w.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8) / fp8_max
+            q = (w / scale).clamp(-fp8_max, fp8_max).to(torch.float8_e4m3fn)
+            return q.float() * scale
+
+        elif method == "per_block":
+            out_feat, in_feat = w.shape
+            # pad to block_size multiples
+            pad_r = (block_size - in_feat % block_size) % block_size
+            pad_b = (block_size - out_feat % block_size) % block_size
+            if pad_r > 0 or pad_b > 0:
+                w_padded = torch.nn.functional.pad(w, (0, pad_r, 0, pad_b))
+            else:
+                w_padded = w
+            po, pi = w_padded.shape
+            w_blocks = w_padded.reshape(po // block_size, block_size, pi // block_size, block_size)
+            w_blocks = w_blocks.permute(0, 2, 1, 3)  # [bo, bi, bs, bs]
+            scale = w_blocks.abs().amax(dim=(-2, -1), keepdim=True).clamp(min=1e-8) / fp8_max
+            q = (w_blocks / scale).clamp(-fp8_max, fp8_max).to(torch.float8_e4m3fn)
+            w_qdq = (q.float() * scale).permute(0, 2, 1, 3).reshape(po, pi)
+            return w_qdq[:out_feat, :in_feat]
+
+        elif method == "per_group":
+            # FP8 per_group: group along dim=1
+            out_feat, in_feat = w.shape
+            gs = group_size if group_size > 0 else in_feat
+            if in_feat % gs != 0:
+                pad_len = gs - in_feat % gs
+                w_padded = torch.nn.functional.pad(w, (0, pad_len))
+            else:
+                w_padded = w
+                pad_len = 0
+            w_grouped = w_padded.reshape(out_feat, -1, gs)
+            scale = w_grouped.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8) / fp8_max
+            q = (w_grouped / scale).clamp(-fp8_max, fp8_max).to(torch.float8_e4m3fn)
+            w_qdq = (q.float() * scale).reshape(out_feat, -1)
+            if pad_len > 0:
+                w_qdq = w_qdq[:, :in_feat]
+            return w_qdq
+
+        else:
+            raise ValueError(f"Unknown weight method for FP8: {method}")
+
+    else:
+        raise ValueError(f"Unknown weight quant_type: {quant_type}")
+
+
+# ---------------------------------------------------------------------------
+# SmoothAlphaValueHook — capture raw activation for dense MLP down_proj
+# ---------------------------------------------------------------------------
+
+class SmoothAlphaValueHook:
+    """Capture raw down_proj input activation for alpha grid search.
+
+    Stores up to ``max_tokens`` token-rows per layer via CPU offload
+    with uniform sub-sampling when the cap is exceeded.
+
+    Works alongside SmoothDownProjInputHook (which collects absmax/ema
+    statistics); this hook stores the actual tensor values.
+
+    Args:
+        layer_name: down_proj module name (same key used in ``_smooth_stats``).
+        alpha_search_values: shared dict ``{layer_name: {"tokens": Tensor|None}}``.
+        max_tokens: maximum token-rows to keep per layer.
+    """
+
+    def __init__(self, layer_name, alpha_search_values, max_tokens=4096):
+        self.layer_name = layer_name
+        self.alpha_search_values = alpha_search_values
+        self.max_tokens = max_tokens
+
+    def __call__(self, module, input, output):
+        act = input[0] if isinstance(input, tuple) else input
+        if not isinstance(act, torch.Tensor):
+            return
+
+        with torch.no_grad():
+            act_cpu = act.detach().float().cpu()
+            stored = self.alpha_search_values[self.layer_name]
+            if stored["tokens"] is None:
+                stored["tokens"] = act_cpu
+            else:
+                stored["tokens"] = torch.cat([stored["tokens"], act_cpu], dim=0)
+            # Uniform sub-sample when cap exceeded
+            if stored["tokens"].shape[0] > self.max_tokens:
+                indices = torch.linspace(
+                    0, stored["tokens"].shape[0] - 1, self.max_tokens
+                ).long()
+                stored["tokens"] = stored["tokens"][indices]
+
+
+# ---------------------------------------------------------------------------
+# MoE raw tensor capture (kernel injection)
+# ---------------------------------------------------------------------------
+
+# Module-level cache for VLLM_MOE_COLLECT_ALPHA_SEARCH flag.
+# Initialised from env var so that *every* import of this module (including
+# the one inside fused_moe.py which is a separate module instance from the
+# angelslim.compressor.quant.core.vllm_calibrate_utils import) starts with
+# the correct value when the env var is set by the caller script.
+_MOE_COLLECT_ALPHA_SEARCH = os.getenv("VLLM_MOE_COLLECT_ALPHA_SEARCH", "0") == "1"
+
+
+def _set_moe_collect_alpha_search(enable: bool) -> None:
+    """Update the module-level MoE alpha-search collection flag."""
+    global _MOE_COLLECT_ALPHA_SEARCH
+    _MOE_COLLECT_ALPHA_SEARCH = bool(enable)
+
+
+def collect_fused_moe_alpha_search_values(
+    stage,
+    hidden_states,
+    topk_ids,
+    layer_name=None,
+    alpha_search_values=None,
+    max_tokens_per_expert=512,
+):
+    """Collect per-expert raw activation tensors for alpha grid search.
+
+    Called from inside the vLLM FusedMoE kernel (requires source modification),
+    at the same injection point as ``collect_fused_moe_smooth_stats``.
+
+    Args:
+        stage: must be "down_proj"
+        hidden_states: [num_tokens * top_k, intermediate_size_shard]
+        topk_ids: [num_tokens, top_k]
+        layer_name: FusedMoE layer name
+        alpha_search_values: model._alpha_search_values dict
+        max_tokens_per_expert: cap per expert
+    """
+    
+    if alpha_search_values is None or layer_name is None:
+        return
+    if stage != "down_proj":
+        return
+
+    with torch.no_grad():
+        act = hidden_states
+        if act.dim() == 1:
+            act = act.unsqueeze(0)
+
+        num_tokens_hs = act.shape[0]
+        num_tokens_topk = topk_ids.shape[0]
+        top_k = topk_ids.shape[1]
+
+        if num_tokens_hs == num_tokens_topk * top_k:
+            flat_expert_ids = topk_ids.reshape(-1)
+        else:
+            return  # shape mismatch, skip
+
+        for expert_id_tensor in flat_expert_ids.unique():
+            expert_id = expert_id_tensor.item()
+            if expert_id < 0:
+                continue
+            expert_key = f"{layer_name}.{expert_id}.down_proj"
+            mask = flat_expert_ids == expert_id_tensor
+            expert_act = act[mask].detach().float().cpu()
+            if expert_act.numel() == 0:
+                continue
+
+            if expert_key not in alpha_search_values:
+                alpha_search_values[expert_key] = {"tokens": None}
+            stored = alpha_search_values[expert_key]
+            if stored["tokens"] is None:
+                stored["tokens"] = expert_act
+            else:
+                stored["tokens"] = torch.cat([stored["tokens"], expert_act], dim=0)
+            # Cap
+            if stored["tokens"].shape[0] > max_tokens_per_expert:
+                indices = torch.linspace(
+                    0, stored["tokens"].shape[0] - 1, max_tokens_per_expert
+                ).long()
+                stored["tokens"] = stored["tokens"][indices]
+
+
+# ---------------------------------------------------------------------------
+# setup / remove alpha search hooks
+# ---------------------------------------------------------------------------
+
+def setup_smooth_alpha_search_hooks(
+    model,
+    max_tokens=4096,
+    collect_moe=True,
+):
+    """Register hooks to capture raw down_proj activations for alpha grid search.
+
+    Must be called via ``llm.apply_model()`` AFTER ``setup_smooth_hooks()``.
+
+    Dense MLP: registers SmoothAlphaValueHook on each down_proj layer.
+    MoE: wires w13_weight attributes so that ``collect_fused_moe_alpha_search_values``
+         (called from the kernel injection point) stores raw tensors per expert.
+
+    Returns a summary string.
+    """
+    from vllm.model_executor.layers.linear import LinearBase
+
+    if not hasattr(model, "_alpha_search_values"):
+        model._alpha_search_values = {}
+    if not hasattr(model, "_alpha_search_hooks"):
+        model._alpha_search_hooks = []
+
+    # --- Dense MLP down_proj ---
+    all_linear = _find_layers(model, layers=[torch.nn.Linear, LinearBase])
+    down_proj_layers = {
+        name: module
+        for name, module in all_linear.items()
+        if name.split(".")[-1] == "down_proj"
+    }
+
+    for name, layer in down_proj_layers.items():
+    
+        if name not in model._alpha_search_values:
+            model._alpha_search_values[name] = {"tokens": None}
+        hook = SmoothAlphaValueHook(name, model._alpha_search_values, max_tokens)
+        handle = layer.register_forward_hook(hook)
+        model._alpha_search_hooks.append(handle)
+
+    # --- MoE (kernel injection) ---
+    moe_count = 0
+    if collect_moe:
+        try:
+            from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+            moe_layers = _find_layers(model, layers=[FusedMoE])
+        except ImportError:
+            moe_layers = {}
+
+        if moe_layers:
+            os.environ["VLLM_MOE_COLLECT_ALPHA_SEARCH"] = "1"
+            _set_moe_collect_alpha_search(True)
+
+        per_expert_max = max(1, max_tokens // 8) # for topk=8
+        for name, layer in moe_layers.items():
+            
+            if hasattr(layer, "w13_weight") and layer.w13_weight is not None:
+                layer.w13_weight._alpha_search_values_of_model = model._alpha_search_values
+                layer.w13_weight._vllm_layer_name_smooth = name
+                layer.w13_weight._alpha_search_max_tokens = per_expert_max
+                moe_count += 1
+            else:
+                print(
+                    f"[DEBUG] Cannot set smooth attrs on w13_weight for {name}: "
+                    f"hasattr={hasattr(layer, 'w13_weight')}, "
+                    f"is_none={getattr(layer, 'w13_weight', None) is None}"
+                )
+    total = len(model._alpha_search_hooks)
+    msg = (
+        f"Registered {total} alpha-search hooks (dense down_proj), "
+        f"{moe_count} MoE layers wired"
+    )
+    print(f"[Alpha Search] {msg}")
+    return msg
+
+
+def remove_smooth_alpha_search_hooks(model):
+    """Remove alpha-search hooks and free stored activation tensors."""
+    if hasattr(model, "_alpha_search_hooks"):
+        for handle in model._alpha_search_hooks:
+            handle.remove()
+        model._alpha_search_hooks.clear()
+    if hasattr(model, "_alpha_search_values"):
+        del model._alpha_search_values
+    os.environ.pop("VLLM_MOE_COLLECT_ALPHA_SEARCH", None)
+    _set_moe_collect_alpha_search(False)
+    return "Alpha-search hooks removed"
+
+
+# ---------------------------------------------------------------------------
+# _get_down_proj_weight — resolve weight tensor for dense / MoE
+# ---------------------------------------------------------------------------
+
+def _get_down_proj_weight(model, layer_key):
+    """Get the down_proj weight tensor (TP-local shard) for a given layer key.
+
+    Dense MLP key: "model.layers.0.mlp.down_proj"
+      → model.get_submodule(key).weight   [out, in_shard]
+
+    MoE expert key: "model.layers.3.mlp.experts.42.down_proj"
+      → parse moe_layer = "model.layers.3.mlp.experts"
+      → expert_id = 42
+      → FusedMoE.w2_weight[expert_id]     [out, in_shard]
+
+    Returns weight tensor (detached) or None.
+    """
+    import re
+
+    # Try direct submodule access (works for dense MLP)
+    try:
+        mod = model.get_submodule(layer_key)
+        if hasattr(mod, "weight"):
+            return mod.weight.detach()
+    except (AttributeError, ValueError):
+        pass
+
+    # MoE pattern: *.experts.<expert_id>.down_proj
+    moe_match = re.match(r"^(.+)\.(\d+)\.down_proj$", layer_key)
+    if moe_match:
+        moe_prefix = moe_match.group(1)  # e.g. "model.layers.3.mlp.experts"
+        expert_id = int(moe_match.group(2))
+        try:
+            moe_module = model.get_submodule(moe_prefix)
+        except (AttributeError, ValueError):
+            # Try one level up (experts might be inside FusedMoE)
+            parent = moe_prefix.rsplit(".", 1)[0] if "." in moe_prefix else moe_prefix
+            try:
+                moe_module = model.get_submodule(parent)
+            except (AttributeError, ValueError):
+                return None
+
+        # FusedMoE stores w2 (down_proj) as w2_weight: [num_experts, out, in_shard]
+        w2 = getattr(moe_module, "w2_weight", None)
+        if w2 is not None and expert_id < w2.shape[0]:
+            return w2[expert_id].detach()
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# SmoothAlphaSearcher — core grid search callable
+# ---------------------------------------------------------------------------
+
+class SmoothAlphaSearcher:
+    """Per-layer alpha grid search for SmoothQuant down_proj.
+
+    Must be called via ``llm.apply_model()`` **before** ``get_smooth_stats()``
+    so that ``model._smooth_stats`` still contains the TP-local shard of absmax.
+
+    Each rank independently searches its own shard, then ``all_gather`` is
+    used to concatenate ``smooth_weight`` shards into the full
+    ``[intermediate_size]`` vector.
+
+    Usage::
+
+        searcher = SmoothAlphaSearcher(config, output_path="path/to/output.json")
+        summary_list = llm.apply_model(searcher)
+        # Results are saved to output_path by rank 0 inside the worker.
+    """
+
+    def __init__(self, config: SmoothAlphaSearchConfig, output_path: str = None):
+        self.config = config
+        self.output_path = output_path
+
+    def __call__(self, model):
+        import torch.distributed as dist
+
+        rank, world_size = _get_dist_info()
+        smooth_stats = getattr(model, "_smooth_stats", {})
+        alpha_values = getattr(model, "_alpha_search_values", {})
+
+        if not alpha_values:
+            print("[SmoothAlphaSearcher] No activation tensors collected, skipping.")
+            return {}
+
+        cfg = self.config
+        alphas = torch.linspace(cfg.alpha_min, cfg.alpha_max, cfg.alpha_steps).tolist()
+        use_gpu = torch.cuda.is_available()
+        device = (
+            torch.device("cuda", torch.cuda.current_device())
+            if use_gpu
+            else torch.device("cpu")
+        )
+
+        results = {}
+        processed = 0
+        skipped = 0
+
+        for layer_key, stored in alpha_values.items():
+            x_cpu = stored.get("tokens")
+            if x_cpu is None or x_cpu.shape[0] == 0:
+                skipped += 1
+                continue
+
+            # --- Get weight ---
+            print(f"[SmoothAlphaSearcher] Processing layer {layer_key}")
+            w_tensor = _get_down_proj_weight(model, layer_key)
+            if w_tensor is None:
+                skipped += 1
+                continue
+
+            # --- Get local shard of absmax (pre-all_gather) ---
+            stat_key = layer_key
+            stat = smooth_stats.get(stat_key)
+            if stat is None or stat.get("absmax") is None:
+                skipped += 1
+                continue
+            local_absmax = stat["ema" if cfg.use_ema_for_absmax else "absmax"]
+            if local_absmax is None:
+                local_absmax = stat["absmax"]
+            if local_absmax is None:
+                skipped += 1
+                continue
+
+            # --- Move to device ---
+            x = x_cpu.to(device)
+            w = w_tensor.float().to(device)
+            act_absmax = local_absmax.float().to(device).clamp(min=1e-8)
+            weight_absmax = w.abs().max(dim=0).values.clamp(min=1e-8)
+
+            # --- Reference output (computed once) ---
+            y_ref = x @ w.T  # [N, out_feat]
+
+            # --- Grid search no tensor-wise activation mode ---
+
+            losses = torch.empty(len(alphas), device=device)
+            if cfg.smooth_search_mode == 'default':
+                for i, alpha in enumerate(alphas):
+                    smooth = (
+                        act_absmax.pow(alpha) / weight_absmax.pow(1.0 - alpha)
+                    ).clamp(1e-6, 1e6)
+
+                    x_smoothed = x / smooth.unsqueeze(0)
+                    w_smoothed = w * smooth.unsqueeze(0)
+
+                    x_q = _smooth_qdq_act(
+                        x_smoothed,
+                        method=cfg.act_quant_method,
+                        quant_type=cfg.act_quant_type,
+                        bits=cfg.weight_quant_bits,
+                    )
+                    w_q = _smooth_qdq_weight(
+                        w_smoothed,
+                        method=cfg.weight_quant_method,
+                        quant_type=cfg.weight_quant_type,
+                        bits=cfg.weight_quant_bits,
+                        group_size=cfg.weight_group_size,
+                        block_size=cfg.block_size,
+                    )
+                    y_q = x_q @ w_q.T
+                    losses[i] = ((y_ref - y_q) ** 2).mean()
+
+            # --- Grid search tensor-wise activation mode ---
+            # this mode search multipy with activation abs_max(per-tensor)
+            elif cfg.smooth_search_mode == 'per-tensor-act-first':
+                per_tensor_act_absmax = act_absmax.max()
+                mul_list = torch.linspace(cfg.act_mul_min, cfg.act_mul_max, cfg.alpha_steps).tolist()
+                for i, mul in enumerate(mul_list):
+                    tgt_absmax = mul * per_tensor_act_absmax
+                    # calculate smooth weight
+                    # smooth all act channel to tgt_absmax
+                    smooth = act_absmax / tgt_absmax
+
+                    # not too big for smooth
+                    smooth = smooth.clamp(cfg.smooth_min, cfg.smooth_max)
+                    x_smoothed = x / smooth.unsqueeze(0)
+                    w_smoothed = w * smooth.unsqueeze(0)
+
+                    x_q = _smooth_qdq_act(
+                        x_smoothed,
+                        method=cfg.act_quant_method,
+                        quant_type=cfg.act_quant_type,
+                        bits=cfg.weight_quant_bits,
+                    )
+                    w_q = _smooth_qdq_weight(
+                        w_smoothed,
+                        method=cfg.weight_quant_method,
+                        quant_type=cfg.weight_quant_type,
+                        bits=cfg.weight_quant_bits,
+                        group_size=cfg.weight_group_size,
+                        block_size=cfg.block_size,
+                    )
+                    y_q = x_q @ w_q.T
+                    losses[i] = ((y_ref - y_q) ** 2).mean()
+
+
+            best_idx = int(losses.argmin().item())
+
+            if cfg.smooth_search_mode == 'per-tensor-act-first':
+                best_mul = mul_list[best_idx]
+                best_tgt = best_mul * per_tensor_act_absmax
+                best_smooth = (act_absmax / best_tgt).clamp(cfg.smooth_min, cfg.smooth_max)
+                best_alpha = best_mul  # store the mul factor as "alpha" for this mode
+            else:
+                best_alpha = alphas[best_idx]
+                best_smooth = (
+                    act_absmax.pow(best_alpha) / weight_absmax.pow(1.0 - best_alpha)
+                ).clamp(cfg.smooth_min, cfg.smooth_max)
+
+            results[layer_key] = {
+                "alpha": best_alpha,
+                "smooth_weight_shard": best_smooth.cpu(),
+                "loss": losses[best_idx].item(),
+            }
+            processed += 1
+
+            # Free GPU memory (keep tensors on CPU, but don't call
+            # empty_cache inside the loop — it's very slow and can
+            # interfere with vLLM's memory allocator).
+            del x, w, y_ref, act_absmax, weight_absmax, x_cpu
+
+        print(
+            f"[SmoothAlphaSearcher] rank={rank}: processed={processed}, "
+            f"skipped={skipped}, total_keys={len(alpha_values)}"
+        )
+
+        # --- all_gather: concatenate shards across TP ranks ---
+        if world_size > 1 and dist.is_initialized():
+            # Batch all_gather: stack all smooth_weight shards into one tensor,
+            # do a single all_gather, then split back. This avoids thousands of
+            # individual NCCL calls which can trigger cudaErrorIllegalAddress.
+            keys_list = sorted(results.keys())
+            if keys_list:
+                # --- smooth_weight shards ---
+                sw_list = [results[k]["smooth_weight_shard"] for k in keys_list]
+                sw_sizes = [s.numel() for s in sw_list]
+                sw_flat = torch.cat([s.reshape(-1) for s in sw_list]).cuda()
+                gathered_flat = [torch.zeros_like(sw_flat) for _ in range(world_size)]
+                dist.all_gather(gathered_flat, sw_flat)
+                # concat along TP dim for each key
+                offset = 0
+                for i, key in enumerate(keys_list):
+                    sz = sw_sizes[i]
+                    chunks = [g[offset:offset + sz].cpu() for g in gathered_flat]
+                    results[key]["smooth_weight"] = torch.cat(chunks, dim=0).tolist()
+                    offset += sz
+
+                # --- alpha values ---
+                alpha_flat = torch.tensor(
+                    [results[k]["alpha"] for k in keys_list],
+                    dtype=torch.float32,
+                ).cuda()
+                gathered_alpha = [torch.zeros_like(alpha_flat) for _ in range(world_size)]
+                dist.all_gather(gathered_alpha, alpha_flat)
+                for i, key in enumerate(keys_list):
+                    results[key]["alpha"] = [g[i].item() for g in gathered_alpha]
+
+                for key in keys_list:
+                    results[key].pop("smooth_weight_shard", None)
+
+                del sw_flat, gathered_flat, alpha_flat, gathered_alpha
+                if use_gpu:
+                    torch.cuda.empty_cache()
+
+            dist.barrier()
+        else:
+            for key in results:
+                entry = results[key]
+                entry["smooth_weight"] = entry.pop("smooth_weight_shard").tolist()
+                entry["alpha"] = [entry["alpha"]]
+
+        # --- Save results to file on rank 0 (avoids pickling the huge
+        # dict back through the mp executor which can OOM / hang). ---
+        num_results = len(results)
+        if self.output_path and rank == 0 and results:
+            import json as _json
+            output_data = {
+                "config": {
+                    "alpha_min": cfg.alpha_min,
+                    "alpha_max": cfg.alpha_max,
+                    "alpha_steps": cfg.alpha_steps,
+                    "act_quant_method": cfg.act_quant_method,
+                    "act_quant_type": cfg.act_quant_type,
+                    "weight_quant_method": cfg.weight_quant_method,
+                    "weight_quant_type": cfg.weight_quant_type,
+                    "weight_quant_bits": cfg.weight_quant_bits,
+                },
+                "results": results,
+            }
+            os.makedirs(os.path.dirname(self.output_path) or ".", exist_ok=True)
+            with open(self.output_path, "w") as f:
+                _json.dump(output_data, f, indent=2)
+            print(f"[SmoothAlphaSearcher] rank=0 saved {num_results} results to {self.output_path}")
+
+        # Return only a lightweight summary (NOT the full results dict)
+        # to avoid serialisation issues with mp executor.
+        return f"processed={num_results}"

--- a/configs/hy3/ptq/hy3_smooth.yaml
+++ b/configs/hy3/ptq/hy3_smooth.yaml
@@ -1,0 +1,60 @@
+# HY3 Smooth 量化统一配置
+# Phase 1 入口: tools/run_vllm_smooth.py -c configs/hy3/ptq/hy3_smooth.yaml
+# Phase 2 入口: tools/convert_smooth_weights.py -c configs/hy3/ptq/hy3_smooth.yaml
+#
+# 两个脚本共享本文件，各自读取所需字段。
+# CLI 显式传参 > YAML 值 > argparse 默认值。
+
+# # ========== 路径（两阶段共用） ==========
+model_path: /path/to/model
+ptq_data_path: /path/to/dataset.jsonl
+output_dir: /path/to/smooth_output        # Phase 1 写入, Phase 2 读取
+save_path: /path/to/smoothed_model        # Phase 2 输出
+
+# ========== Phase 1: 模型加载 / 运行时 ==========
+tp_size: 16
+batch_size: 4
+num_samples: 16
+max_length: 16384
+distributed_executor_backend: ray
+skip_weight_loading: false
+verbose: false
+
+# ========== Phase 1: 收集范围 ==========
+collect_attn: true
+collect_down_proj: true
+collect_moe: true
+ema_momentum: 0.9
+
+# ========== Phase 2: Smooth 类型与 Alpha ==========
+smooth_qk: true
+smooth_vo: true
+smooth_down: true
+alpha_qk: 0.6
+alpha_vo: 0.5
+alpha_down: 0.6              # 无 alpha search 结果的 key 使用此值
+use_ema: false
+device: cpu
+dtype: auto
+
+# ========== Alpha Grid Search（Phase 1 执行, Phase 2 自动应用） ==========
+enable_alpha_search: true
+num_search_samples: 16
+search_max_length: 8192
+alpha_min: 0.3
+alpha_max: 1.0
+alpha_steps: 8
+alpha_act_quant_method: per_tensor
+alpha_act_quant_type: fp8
+alpha_weight_quant_method: per_tensor
+alpha_weight_quant_type: fp8
+alpha_weight_quant_bits: 8
+alpha_weight_group_size: 128
+alpha_max_tokens: 4096
+alpha_use_ema: false
+alpha_smooth_search_mode: default
+# per-tensor-act-first 模式参数（仅 mode=per-tensor-act-first 时生效）
+# alpha_act_mul_min: 0.1
+# alpha_act_mul_max: 1.0
+# alpha_smooth_min: 1e-6
+# alpha_smooth_max: 1e6

--- a/scripts/ptq/README.md
+++ b/scripts/ptq/README.md
@@ -115,13 +115,47 @@ bash tools/vllm_patch/install.sh --help      # 查看完整用法
 
 ## 二、HY3.0 系列脚本（Hunyuan-A20B 等 HY3 模型）
 
-下面 3 个脚本共享同一套 vLLM 运行时环境（chunked prefill / FlashInfer attention / mp distributed executor / fused MoE 等），区别在于产出物不同。
+下面 6 个脚本共享同一套 vLLM 运行时环境（chunked prefill / FlashInfer attention / mp distributed executor / fused MoE 等），区别在于产出物不同。
 
 | 脚本 | 用途 | 入口 |
 | --- | --- | --- |
 | [`run_vllm_quant_for_HY3.sh`](./run_vllm_quant_for_HY3.sh) | ★ 推荐的"一键流水线"：校准 + 量化 | `tools/run_vllm_calibrate.py` + `tools/fp8_quant_with_vllm_activation.py` |
 | [`run_vllm_calibrate_for_HY3.sh`](./run_vllm_calibrate_for_HY3.sh) | 仅 W8A8C8 联合校准 | `tools/run_vllm_calibrate.py` |
 | [`run_kvcache_calibrate_for_HY3.sh`](./run_kvcache_calibrate_for_HY3.sh) | 仅 KV-cache 校准（轻量） | `tools/kvcache/run_kvcache_calibrate.py` |
+| [`run_smooth_for_HY3.sh`](./run_smooth_for_HY3.sh) | SmoothQuant 一键流水线：统计收集 + 权重变换 | `tools/smooth/run_vllm_smooth.py` + `tools/smooth/convert_smooth_weights.py` |
+| [`run_smooth_calibrate_for_HY3.sh`](./run_smooth_calibrate_for_HY3.sh) | 仅 Smooth 统计收集（+ 可选 Alpha 搜索） | `tools/smooth/run_vllm_smooth.py` |
+| [`run_smooth_convert_for_HY3.sh`](./run_smooth_convert_for_HY3.sh) | 仅 Smooth 离线权重变换 | `tools/smooth/convert_smooth_weights.py` |
+
+> 📖 SmoothQuant 完整文档（核心概念、配置详解、Alpha 搜索原理、故障排查）见 [tools/smooth/README.md](../../tools/smooth/README.md)。
+
+---
+
+### 0. `run_smooth_for_HY3.sh` — 可选的模型 Smooth 转换
+
+**功能**：Smooth 预处理（生成平滑后的模型），可作为后续 FP8 量化的前置步骤，提升低比特量化精度。
+
+```bash
+bash run_smooth_for_HY3.sh                    # 两阶段都跑
+bash run_smooth_for_HY3.sh --skip-calibrate   # 仅 Phase 2（复用已有统计）
+bash run_smooth_for_HY3.sh --skip-convert     # 仅 Phase 1
+```
+
+#### Phase 1：调用 `tools/smooth/run_vllm_smooth.py`
+
+- 用 vLLM 加载模型，在校准数据集上跑前向，收集 Attention / MLP / MoE 各层的 per-channel 激活统计（absmax + EMA）。
+- 可选执行 per-layer Alpha 网格搜索，自动寻找最优平滑参数。
+- 输出到 `${output_dir}`：
+  - `smooth_stats.json` — 各层 per-channel absmax / EMA 统计
+  - `smooth_alpha_search.json`（若 `enable_alpha_search: true`）— 每层最优 alpha 及对应的 smooth_weight
+
+#### Phase 2：调用 `tools/smooth/convert_smooth_weights.py`
+
+- 读取 Phase 1 产出的统计文件，对 QK / VO / Down 投影层权重做离线缩放变换。
+- 输出到 `${save_path}`：平滑后的 HuggingFace safetensors 模型（可直接用于后续量化或推理）。
+
+#### 配置
+
+默认读取 `configs/hy3/ptq/hy3_smooth.yaml`（Phase 1 和 Phase 2 共享同一份 YAML）。详见 [tools/smooth/README.md](../../tools/smooth/README.md)。
 
 ---
 

--- a/scripts/ptq/run_smooth_calibrate_for_HY3.sh
+++ b/scripts/ptq/run_smooth_calibrate_for_HY3.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Phase 1 only: Collect Smooth Stats (+ optional Alpha Search).
+# Must be run from the AngelSlim repository root directory.
+
+set -euo pipefail
+
+CONFIG="configs/hy3/ptq/hy3_smooth.yaml"
+
+# -------- Environment Variables --------
+# Allow function serialization for apply_model in vLLM v1 engine
+export VLLM_ALLOW_INSECURE_SERIALIZATION=1
+# Enable MoE expert statistics collection
+export VLLM_MOE_COLLECT_STATS=1
+# Force Ray to reload code (disable code caching)
+export RAY_DEDUP_LOGS=0
+# Force Python to not use bytecode cache
+export PYTHONDONTWRITEBYTECODE=1
+# Disable verbose MoE stats logging
+
+export MAX_NUM_BATCHED_TOKENS=32768
+export VLLM_ENABLE_CHUNKED_PREFILL=1
+export MOE_MODE=fused
+export VLLM_ATTENTION_BACKEND=FLASHINFER
+export ASYNC_SCHEDULING=1
+export VLLM_ENABLE_PREFIX_CACHING=1
+export PRECISIONMODE=HF
+
+
+# -------- Environment Variables --------
+export VLLM_MOE_COLLECT_SMOOTH_STATS=1
+export VLLM_MOE_COLLECT_ALPHA_SEARCH=1
+
+
+python3 tools/smooth/run_vllm_smooth.py -c "$CONFIG" "$@"

--- a/scripts/ptq/run_smooth_convert_for_HY3.sh
+++ b/scripts/ptq/run_smooth_convert_for_HY3.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Phase 2 only: Offline Smooth Weight Conversion.
+# Reads smooth_stats.json (and optionally smooth_alpha_search.json) from output_dir.
+# Must be run from the AngelSlim repository root directory.
+
+set -euo pipefail
+
+CONFIG="configs/hy3/ptq/hy3_smooth.yaml"
+
+python3 tools/smooth/convert_smooth_weights.py -c "$CONFIG" "$@"

--- a/scripts/ptq/run_smooth_for_HY3.sh
+++ b/scripts/ptq/run_smooth_for_HY3.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# =============================================================================
+# run_smooth_for_HY3.sh — One-click smooth pipeline: calibration + conversion.
+#
+# Usage:
+#   bash run_smooth_for_HY3.sh                    # both phases
+#   bash run_smooth_for_HY3.sh --skip-calibrate   # Phase 2 only (reuse stats)
+#   bash run_smooth_for_HY3.sh --skip-convert     # Phase 1 only
+#   bash run_smooth_for_HY3.sh --help
+#
+# NOTE: Must be run from the AngelSlim repository root directory.
+# =============================================================================
+
+set -euo pipefail
+
+CONFIG="configs/hy3/ptq/hy3_smooth.yaml"
+
+SKIP_CALIBRATE=false
+SKIP_CONVERT=false
+for arg in "$@"; do
+    case "$arg" in
+        --skip-calibrate) SKIP_CALIBRATE=true ;;
+        --skip-convert)   SKIP_CONVERT=true ;;
+        --help|-h)
+            echo "Usage: $0 [--skip-calibrate] [--skip-convert] [--help]"
+            echo "  --skip-calibrate  Skip Phase 1 (reuse existing smooth stats)"
+            echo "  --skip-convert    Skip Phase 2 (calibrate only)"
+            exit 0
+            ;;
+    esac
+done
+
+# -------- Environment Variables --------
+# Allow function serialization for apply_model in vLLM v1 engine
+export VLLM_ALLOW_INSECURE_SERIALIZATION=1
+# Enable MoE expert statistics collection
+export VLLM_MOE_COLLECT_STATS=1
+# Force Ray to reload code (disable code caching)
+export RAY_DEDUP_LOGS=0
+# Force Python to not use bytecode cache
+export PYTHONDONTWRITEBYTECODE=1
+# Disable verbose MoE stats logging
+
+export MAX_NUM_BATCHED_TOKENS=32768
+export VLLM_ENABLE_CHUNKED_PREFILL=1
+export MOE_MODE=fused
+export VLLM_ATTENTION_BACKEND=FLASHINFER
+export ASYNC_SCHEDULING=1
+export VLLM_ENABLE_PREFIX_CACHING=1
+export PRECISIONMODE=HF
+
+
+# -------- Environment Variables --------
+export VLLM_MOE_COLLECT_SMOOTH_STATS=1
+export VLLM_MOE_COLLECT_ALPHA_SEARCH=1
+
+export PYTHONPATH=/cfs_cloud_code/gavinlee/work/open_source_smooth/AngelSlim
+# -------- Phase 1: Collect Smooth Stats + Alpha Search --------
+if [ "$SKIP_CALIBRATE" = false ]; then
+    echo "========================================"
+    echo "[Phase 1] Smooth Stats Calibration"
+    echo "========================================"
+    mkdir -p logs
+    python3 tools/smooth/run_vllm_smooth.py -c "$CONFIG" > "logs/smooth.log"| tee -a "logs/smooth.log"
+fi
+
+# -------- Phase 2: Offline Weight Conversion --------
+if [ "$SKIP_CONVERT" = false ]; then
+    echo "========================================"
+    echo "[Phase 2] Offline Weight Conversion"
+    echo "========================================"
+    python3 tools/smooth/convert_smooth_weights.py -c "$CONFIG"
+fi
+
+echo "========================================"
+echo "Done."
+echo "========================================"

--- a/tools/smooth/README.md
+++ b/tools/smooth/README.md
@@ -1,0 +1,838 @@
+# SmoothQuant PTQ 量化脚本说明
+
+本文档介绍 **SmoothQuant** 两阶段离线量化流水线的使用、配置和原理。SmoothQuant 是一种后训练量化（PTQ）技术，通过平滑激活和权重分布，提升低比特量化的精度。
+
+> ⚠️ **前置条件**：本节所有脚本均依赖 [一、环境准备](#环境准备必要条件) 中的 Ray 集群和 vLLM 补丁。**请先完成环境准备再执行 Smooth 脚本。**
+
+---
+
+## 目录
+
+1. [快速开始](#快速开始)
+2. [核心概念](#核心概念)
+3. [两阶段流水线](#两阶段流水线)
+4. [环境准备（必要条件）](#环境准备必要条件)
+5. [脚本使用](#脚本使用)
+6. [配置管理](#配置管理)
+7. [Alpha 网格搜索](#alpha-网格搜索)
+8. [工作流示例](#工作流示例)
+9. [数据格式](#数据格式)
+10. [集成与扩展](#集成与扩展)
+11. [故障排查](#故障排查)
+12. [参考资源](#参考资源)
+
+---
+
+## 快速开始
+
+### 一键执行完整流水线
+
+```bash
+cd /path/to/AngelSlim  # 必须在仓库根目录
+bash scripts/ptq/run_smooth_for_HY3.sh
+```
+
+**分步执行**（调试或复用统计时）：
+
+```bash
+# 仅运行 Phase 1（收集统计，需时较长）
+bash scripts/ptq/run_smooth_calibrate_for_HY3.sh
+
+# 仅运行 Phase 2（应用变换，较快）
+bash scripts/ptq/run_smooth_convert_for_HY3.sh
+
+# Phase 1 完成后，复用其输出的统计再执行 Phase 2
+bash scripts/ptq/run_smooth_for_HY3.sh --skip-calibrate
+```
+
+---
+
+## 核心概念
+
+### SmoothQuant 算法
+
+**目标**：解决 PTQ 中"离群值"导致的量化误差。
+
+**原理**：通过对激活和权重分布进行缩放变换，使其更"均匀"（smooth），从而提高低比特量化精度。
+
+**三类变换**：
+
+| 变换类型 | 应用层 | 作用 |
+| --- | --- | --- |
+| **QK Smooth** | Attention Q/K 投影层 | 平滑注意力查询和键的激活分布 |
+| **VO Smooth** | Attention V/O 投影层 | 平滑 Value 输入和 Output 投影的激活 |
+| **Down Smooth** | MLP Down 投影层 | 平滑前馈网络激活 |
+
+### 关键术语
+
+- **Alpha (α)**：控制平滑强度的参数，范围通常 `[0.3, 1.0]`
+  - α = 0：无平滑（完全依赖权重）
+  - α = 1：完全平滑（完全依赖激活）
+  - 最优 α 因层而异，通过网格搜索获得
+
+- **EMA（指数移动平均）**：在线追踪激活统计的技术，避免全缓存
+  - `ema_momentum`：动量系数，通常 0.9
+  - 更新公式：`new_stat = momentum * old_stat + (1 - momentum) * current_stat`
+
+- **Per-channel 统计**：为每个输出通道独立计算 abs_max 和 EMA 值
+
+---
+
+## 两阶段流水线
+
+### 阶段 1：统计收集与 Alpha 搜索
+
+**任务**：
+1. 在 PTQ 数据集上前向推理，收集激活值统计
+2. 计算每层每通道的 abs_max 和 EMA
+3. 执行可选的 Alpha 网格搜索，找到最优平滑参数
+
+**入口**：`tools/smooth/run_vllm_smooth.py`
+
+**输出**：
+- `smooth_stats.json` — 所有层的 abs_max / EMA 统计
+- `smooth_alpha_search.json`（可选）— 每层搜索得到的最优 alpha
+
+**关键文件**：
+- `angelslim/compressor/quant/core/vllm_calibrate_utils/hooks.py` — 统计钩子
+- `angelslim/compressor/quant/core/vllm_calibrate_utils/search.py` — Alpha 搜索实现
+
+### 阶段 2：离线权重变换
+
+**任务**：
+1. 读取阶段 1 产出的统计文件
+2. 根据 alpha 值和统计，对权重进行缩放变换
+3. 输出平滑后的权重到 HuggingFace safetensors 格式
+
+**入口**：`tools/smooth/convert_smooth_weights.py`
+
+**输出**：
+- `{save_path}/` — 平滑后的模型（safetensors 格式）
+
+**关键文件**：
+- `angelslim/compressor/quant/modules/smooth/smooth.py` — 核心变换实现
+- `tools/smooth/convert_smooth_weights.py` — 权重处理和转换逻辑
+
+---
+
+## 环境准备（必要条件）
+
+### 1. Ray 集群与 vLLM 补丁
+
+**必须先完成** `scripts/ptq/README.md` 中"一、环境准备"的两步：
+
+1. **搭建 Ray 集群**（2 节点 × 8 卡 = 16 卡）
+2. **给 vLLM 打 AngelSlim 补丁**
+
+```bash
+# 检查补丁是否已安装
+bash tools/vllm_patch/install.sh check
+
+# 若未安装，执行一键安装（在每个 Ray 节点上运行）
+bash tools/vllm_patch/install.sh install
+```
+
+### 2. 环境变量
+
+Smooth 脚本会自动设置以下环境变量，无需手动配置：
+
+```bash
+export VLLM_MOE_COLLECT_SMOOTH_STATS=1          # 启用 Smooth 统计收集
+export VLLM_MOE_COLLECT_ALPHA_SEARCH=1          # 启用 Alpha 搜索
+export VLLM_ALLOW_INSECURE_SERIALIZATION=1      # 允许不安全序列化
+export PYTHONPATH=<AngelSlim_root>              # 确保 angelslim 包可导入
+```
+
+---
+
+## 脚本使用
+
+### 1. `run_smooth_for_HY3.sh` ★ 推荐的一键流水线
+
+**功能**：自动执行 Phase 1 + Phase 2，完成完整的 Smooth 量化流程。
+
+**用法**：
+
+```bash
+# 标准用法：执行 Phase 1 + Phase 2
+bash scripts/ptq/run_smooth_for_HY3.sh
+
+# 仅执行 Phase 2（复用已有的 smooth_stats.json）
+bash scripts/ptq/run_smooth_for_HY3.sh --skip-calibrate
+
+# 仅执行 Phase 1（调试或仅收集统计）
+bash scripts/ptq/run_smooth_for_HY3.sh --skip-convert
+
+# 查看帮助
+bash scripts/ptq/run_smooth_for_HY3.sh --help
+```
+
+**运行日志示例**：
+
+```
+========================================
+[Phase 1] Smooth Stats Calibration
+========================================
+[2025-05-26 10:15:23] Loading model: /path/to/model ...
+[2025-05-26 10:15:45] Setting up hooks for smooth stats collection ...
+[2025-05-26 10:20:18] Processing 512 samples, max_length=16384 ...
+[2025-05-26 10:35:42] Phase 1 complete. Output: /path/to/output_dir/smooth_stats.json
+[2025-05-26 10:35:43] Starting alpha search (enable_alpha_search=true) ...
+[2025-05-26 10:45:20] Alpha search complete: /path/to/output_dir/smooth_alpha_search.json
+========================================
+[Phase 2] Offline Weight Conversion
+========================================
+[2025-05-26 10:45:21] Reading stats from: /path/to/output_dir/smooth_stats.json
+[2025-05-26 10:45:22] Applying QK smooth ...
+[2025-05-26 10:50:15] Applying VO smooth ...
+[2025-05-26 10:55:30] Applying down_proj smooth ...
+[2025-05-26 11:05:45] Saving smoothed model to: /path/to/save_path/
+========================================
+Done.
+========================================
+```
+
+### 2. `run_smooth_calibrate_for_HY3.sh` — 仅 Phase 1
+
+**功能**：独立运行 Phase 1（统计收集 + 可选 Alpha 搜索）。
+
+**用法**：
+
+```bash
+bash scripts/ptq/run_smooth_calibrate_for_HY3.sh
+```
+
+**何时使用**：
+
+- 需要多次调整 `alpha_min`、`alpha_max`、`alpha_steps` 等搜索参数，复用统计结果
+- 需要手工检查或修改 `smooth_stats.json` 或 `smooth_alpha_search.json`
+- 需要与其他工具链集成（如自定义量化后处理）
+
+### 3. `run_smooth_convert_for_HY3.sh` — 仅 Phase 2
+
+**功能**：独立运行 Phase 2（离线权重变换）。
+
+**用法**：
+
+```bash
+bash scripts/ptq/run_smooth_convert_for_HY3.sh
+```
+
+**前置条件**：必须已有 `output_dir` 下的 `smooth_stats.json` 文件（通常来自阶段 1）。
+
+**何时使用**：
+
+- 已有来自阶段 1 的 `smooth_stats.json`，想测试不同的 `alpha_qk` / `alpha_vo` / `alpha_down` 值
+- 阶段 1 成功完成，阶段 2 因故障中断，需要单独重跑
+- 线下编辑 `smooth_stats.json` 进行手工调试
+
+---
+
+## 配置管理
+
+### 配置文件位置
+
+所有 Smooth 脚本共享同一套 YAML 配置，默认为：
+
+```
+configs/hy3/ptq/hy3_smooth.yaml
+```
+
+### 关键配置项
+
+#### 路径配置
+
+```yaml
+# Phase 1 读取；Phase 2 读取和输出 stats 的位置
+model_path: /path/to/hunyuan/model
+
+# Phase 1 读取的 PTQ 校准数据集
+ptq_data_path: /path/to/calibration_data.jsonl
+
+# Phase 1 输出 smooth_stats.json 和 smooth_alpha_search.json 的目录
+output_dir: /path/to/smooth_output
+
+# Phase 2 输出平滑权重的目录
+save_path: /path/to/smoothed_model
+```
+
+#### Phase 1 运行时配置
+
+```yaml
+# vLLM 分布式执行参数
+tp_size: 16                                    # Tensor Parallel 卡数
+batch_size: 4                                  # 前向 batch 大小
+num_samples: 512                               # PTQ 数据集采样数
+max_length: 16384                              # 最大序列长度
+distributed_executor_backend: ray              # 使用 Ray 分布式执行
+skip_weight_loading: false                     # 是否跳过权重加载（调试用）
+
+# 统计收集范围
+collect_attn: true                             # 收集 Q/K/V/O 激活统计
+collect_down_proj: true                        # 收集 MLP 激活统计
+collect_moe: true                              # 收集 MoE expert 统计
+ema_momentum: 0.9                              # EMA 指数移动平均动量
+
+verbose: false                                 # 是否输出详细日志
+```
+
+#### Phase 2 变换配置
+
+```yaml
+# 是否启用各类变换
+smooth_qk: true                                # 启用 Q/K 平滑
+smooth_vo: true                                # 启用 V/O 平滑
+smooth_down: true                              # 启用 Down 平滑
+
+# 手工指定的 alpha 值（未进行网格搜索时的默认值）
+alpha_qk: 0.6                                  # Q/K 平滑 alpha
+alpha_vo: 0.5                                  # V/O 平滑 alpha
+alpha_down: 0.6                                # Down 平滑 alpha（无搜索结果时使用）
+
+use_ema: false                                 # 是否使用 EMA 统计（通常 false）
+device: cpu                                    # 权重处理设备
+dtype: auto                                    # 权重数据类型（auto 自动推断）
+```
+
+#### Alpha 网格搜索配置（Phase 1 执行，Phase 2 应用）
+
+```yaml
+# 启用 Alpha 网格搜索
+enable_alpha_search: true
+
+# 搜索参数
+num_search_samples: 16                         # 搜索用的 calibration 样本数
+search_max_length: 8192                        # 搜索用的最大序列长度
+alpha_min: 0.3                                 # 搜索下界
+alpha_max: 1.0                                 # 搜索上界
+alpha_steps: 8                                 # 搜索步数（8 步 => 采样 9 个 alpha 值）
+
+# 量化配置（用于评估搜索得到的 alpha）
+alpha_act_quant_method: per_token              # 激活量化粒度
+alpha_act_quant_type: int8                     # 激活量化类型
+alpha_weight_quant_method: per_channel         # 权重量化粒度
+alpha_weight_quant_type: int8                  # 权重量化类型
+alpha_weight_quant_bits: 8                     # 权重位宽
+alpha_weight_group_size: 128                   # 权重分组大小
+alpha_max_tokens: 4096                         # 搜索过程中的最大 token 数
+alpha_use_ema: false                           # 搜索中是否使用 EMA
+alpha_smooth_search_mode: default              # 搜索模式
+```
+
+### 配置示例
+
+#### 典型 HY3 配置
+
+```yaml
+# configs/hy3/ptq/hy3_smooth.yaml
+model_path: /apdcephfs_zwfy14/share_300532381/gavinlee/share_model/one-agent/hunyuan/yonewu/.../ckpt/global_step_hf
+ptq_data_path: /cfs_cloud_code/gavinlee/work/code-RL/data/0521-oneagent/sampled_3000_for_quant_shuf.jsonl
+output_dir: /apdcephfs_zwfy14/share_300532381/.../ckpt/stat_debug
+save_path: /apdcephfs_zwfy14/share_300532381/.../ckpt/smooth_model_debug2
+
+tp_size: 16
+batch_size: 4
+num_samples: 512
+max_length: 16384
+distributed_executor_backend: ray
+
+collect_attn: true
+collect_down_proj: true
+collect_moe: true
+ema_momentum: 0.9
+
+smooth_qk: true
+smooth_vo: true
+smooth_down: true
+alpha_qk: 0.6
+alpha_vo: 0.5
+alpha_down: 0.6
+
+enable_alpha_search: true
+num_search_samples: 16
+alpha_min: 0.3
+alpha_max: 1.0
+alpha_steps: 8
+```
+
+#### 自定义配置（Qwen3 示例）
+
+```yaml
+# configs/qwen3/ptq/smooth_int8/qwen3-8b_int8_dynamic_smooth.yaml
+model_path: /path/to/qwen3-8b
+
+# 数据集
+ptq_data_path: /path/to/calibration.jsonl
+
+# 统计输出目录
+output_dir: /path/to/smooth_stats
+save_path: /path/to/qwen3_smoothed
+
+# 运行时
+tp_size: 8                                     # Qwen3-8B 用较少卡数
+batch_size: 8
+num_samples: 256                               # 更少样本，更快迭代
+max_length: 4096
+
+# 平滑配置
+smooth_qk: true
+smooth_vo: true
+smooth_down: true
+alpha_qk: 0.5
+alpha_vo: 0.4
+alpha_down: 0.5
+
+# Alpha 搜索
+enable_alpha_search: true
+alpha_steps: 6                                 # 更少步数加快搜索
+```
+
+---
+
+## Alpha 网格搜索
+
+### 原理
+
+Alpha 网格搜索的目标是为每一层自动找到最优的 α 值，使得经过 Smooth 变换后的权重，在量化时的误差最小。
+
+### 搜索流程（Phase 1 中执行）
+
+1. **采样配置**：从 PTQ 数据集中采样 `num_search_samples` 个样本
+2. **Alpha 网格**：在 `[alpha_min, alpha_max]` 范围内均匀采样 `alpha_steps + 1` 个 alpha 值
+3. **逐层评估**：对每一层，尝试所有 alpha 值
+4. **量化评估**：对每个 alpha，进行模拟量化，计算量化后的 MSE / 相对误差
+5. **记录最优值**：选择误差最小的 alpha，写入 `smooth_alpha_search.json`
+
+### 输出格式
+
+```json
+{
+  "layer_0": {
+    "attn.q_proj": { "best_alpha": 0.6, "mse": 0.00123 },
+    "attn.k_proj": { "best_alpha": 0.65, "mse": 0.00118 },
+    "attn.v_proj": { "best_alpha": 0.55, "mse": 0.00145 },
+    "attn.o_proj": { "best_alpha": 0.5, "mse": 0.00162 }
+  },
+  "layer_1": {
+    ...
+  }
+}
+```
+
+### 快速迭代建议
+
+**若搜索过程过长**（通常 5-10 小时），可尝试：
+
+```yaml
+alpha_min: 0.4              # 缩小搜索范围（从 0.3 改为 0.4）
+alpha_max: 0.9              # （从 1.0 改为 0.9）
+alpha_steps: 4              # 减少搜索步数（从 8 改为 4）
+num_search_samples: 8       # 减少评估用的样本数（从 16 改为 8）
+search_max_length: 4096     # 减少最大序列长度（从 8192 改为 4096）
+```
+
+---
+
+## 工作流示例
+
+### 示例 1：完整流程（一键执行）
+
+```bash
+cd /path/to/AngelSlim
+
+# 编辑配置文件，指定模型、数据、输出路径
+vim configs/hy3/ptq/hy3_smooth.yaml
+
+# 一键执行 Phase 1 + Phase 2（约 4-6 小时）
+bash scripts/ptq/run_smooth_for_HY3.sh
+
+# 查看输出
+ls -la $(grep "save_path:" configs/hy3/ptq/hy3_smooth.yaml | cut -d' ' -f2)
+```
+
+### 示例 2：调试 Alpha 搜索
+
+```bash
+# 1. 先跑一次快速搜索（较小搜索范围）
+cat > /tmp/smooth_debug.yaml << 'YAML'
+# 复制 hy3_smooth.yaml，修改以下参数
+alpha_steps: 4
+num_search_samples: 8
+search_max_length: 4096
+YAML
+
+# 2. 运行 Phase 1（仅统计收集 + 搜索）
+cp configs/hy3/ptq/hy3_smooth.yaml configs/hy3/ptq/hy3_smooth_debug.yaml
+vim configs/hy3/ptq/hy3_smooth_debug.yaml  # 编辑搜索参数
+
+python3 tools/smooth/run_vllm_smooth.py -c configs/hy3/ptq/hy3_smooth_debug.yaml
+
+# 3. 检查搜索结果
+cat output_dir/smooth_alpha_search.json | python3 -m json.tool | head -50
+
+# 4. 若满意，再用更精细参数重新搜索
+vim configs/hy3/ptq/hy3_smooth_debug.yaml
+python3 tools/smooth/run_vllm_smooth.py -c configs/hy3/ptq/hy3_smooth_debug.yaml
+
+# 5. 查看最终搜索结果
+cat output_dir/smooth_alpha_search.json | python3 -m json.tool
+```
+
+### 示例 3：复用统计进行多次 Phase 2
+
+```bash
+# Phase 1 已完成，假设输出在 /data/smooth_stats
+
+# 方案 A：测试不同的 alpha_qk 值
+for alpha in 0.4 0.5 0.6 0.7; do
+    sed -i "s/alpha_qk: .*/alpha_qk: $alpha/" configs/hy3/ptq/hy3_smooth.yaml
+    sed -i "s|save_path: .*|save_path: /data/smooth_model_alpha_qk_${alpha}|" configs/hy3/ptq/hy3_smooth.yaml
+    bash scripts/ptq/run_smooth_convert_for_HY3.sh
+done
+
+# 方案 B：使用网格搜索结果（自动应用最优 alpha）
+# 若 smooth_alpha_search.json 存在，Phase 2 会自动使用其中的最优 alpha，
+# 忽略手工指定的 alpha_qk / alpha_vo / alpha_down
+```
+
+### 示例 4：集成到现有 PTQ 流水线
+
+```bash
+# 1. 若已有 W8A8C8 量化的模型，先跑 Smooth 统计
+bash scripts/ptq/run_smooth_calibrate_for_HY3.sh
+
+# 2. 应用 Smooth 变换后再量化
+python3 tools/fp8_quant_with_vllm_activation.py \
+    --model-path /data/smooth_model \
+    --stats-dir /data/smooth_output \
+    --fp8-path /data/fp8_smoothed_model
+```
+
+---
+
+## 数据格式
+
+### Phase 1 输出：`smooth_stats.json`
+
+```json
+{
+  "model.layers.0.self_attn.q_proj": {
+    "absmax": [0.234, 0.456, 0.789, ...],      // per-channel absmax，长度 = 输出维度
+    "ema": [0.230, 0.450, 0.780, ...]          // per-channel EMA
+  },
+  "model.layers.0.self_attn.k_proj": {
+    "absmax": [...],
+    "ema": [...]
+  },
+  "model.layers.0.self_attn.v_proj": {
+    "absmax": [...],
+    "ema": [...]
+  },
+  "model.layers.0.mlp.down_proj": {
+    "absmax": [...],
+    "ema": [...]
+  },
+  ...
+}
+```
+
+### Phase 1 输出：`smooth_alpha_search.json`（若启用）
+
+```json
+{
+  "model.layers.0.self_attn.q_proj": {
+    "best_alpha": 0.65,
+    "mse": 0.001234
+  },
+  "model.layers.0.self_attn.k_proj": {
+    "best_alpha": 0.60,
+    "mse": 0.001210
+  },
+  ...
+}
+```
+
+### 变换公式（Phase 2）
+
+#### QK Smooth
+
+```
+smooth_weight = k_absmax^alpha
+q_scaled = q_proj / smooth_weight
+k_scaled = k_proj * smooth_weight
+```
+
+#### VO Smooth
+
+```
+smooth_weight = attn_out_absmax^alpha / o_proj_max^(1-alpha)
+v_scaled = v_proj * smooth_weight
+attn_out_scaled = attn_output / smooth_weight
+o_proj_scaled = o_proj / smooth_weight
+```
+
+#### Down Smooth
+
+```
+smooth_weight = down_proj_absmax^alpha / up_proj_max^(1-alpha)
+mlp_act_scaled = mlp_activation / smooth_weight
+down_scaled = down_proj * smooth_weight
+```
+
+---
+
+## 集成与扩展
+
+### 添加新模型配置
+
+1. **创建模型特定配置**：
+
+```bash
+cp configs/hy3/ptq/hy3_smooth.yaml configs/my_model/ptq/my_model_smooth.yaml
+```
+
+2. **编辑配置文件**：
+
+```yaml
+# configs/my_model/ptq/my_model_smooth.yaml
+model_path: /path/to/my_model
+ptq_data_path: /path/to/my_calibration_data.jsonl
+output_dir: /path/to/my_smooth_output
+save_path: /path/to/my_smooth_model
+
+tp_size: 8                    # 根据模型大小调整
+batch_size: 8
+num_samples: 256
+max_length: 4096
+
+# 其他配置项...
+```
+
+3. **创建快捷脚本**（可选）：
+
+```bash
+# scripts/ptq/run_smooth_for_my_model.sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG="configs/my_model/ptq/my_model_smooth.yaml"
+
+export VLLM_MOE_COLLECT_SMOOTH_STATS=1
+export VLLM_MOE_COLLECT_ALPHA_SEARCH=1
+export VLLM_ALLOW_INSECURE_SERIALIZATION=1
+
+python3 tools/smooth/run_vllm_smooth.py -c "$CONFIG" "$@" && \
+python3 tools/smooth/convert_smooth_weights.py -c "$CONFIG" "$@"
+```
+
+### 自定义 Phase 2 变换
+
+若需自定义 Phase 2 逻辑（如自己的量化后处理），可直接调用核心 API：
+
+```python
+from angelslim.compressor.quant.modules.smooth import SmoothQuant, SmoothConfig
+import json
+
+# 1. 加载统计
+with open("/path/to/smooth_stats.json") as f:
+    smooth_stats = json.load(f)
+
+# 2. 创建配置
+smooth_config = SmoothConfig(
+    alpha=0.6,
+    smooth_first_linears=True,   # Q/K
+    smooth_second_linears=True   # V/O
+)
+
+# 3. 应用变换
+smoother = SmoothQuant(smooth_config)
+model = smoother.convert(model, smooth_stats)
+
+# 4. 后续量化或保存...
+```
+
+### 与其他工具集成
+
+**与 vLLM 量化集成**：
+
+```bash
+# 1. Smooth 处理
+bash scripts/ptq/run_smooth_calibrate_for_HY3.sh
+bash scripts/ptq/run_smooth_convert_for_HY3.sh
+
+# 2. 后续 FP8 量化
+python3 tools/fp8_quant_with_vllm_activation.py \
+    --model-path /data/smooth_model \
+    --ptq-data-path /path/to/calibration_data.jsonl \
+    --fp8-path /data/fp8_smoothed_model
+```
+
+---
+
+## 故障排查
+
+### 问题 1：Ray 集群连接失败
+
+**症状**：`RuntimeError: Job submission client cannot connect to Ray head.`
+
+**解决方案**：
+
+```bash
+# 1. 检查 Ray 集群状态
+ray status
+
+# 2. 若集群未启动，重新启动（参考 README.md 的"环境准备"）
+ray stop
+ray start --head --port 6700 --num-gpus=8
+
+# 3. 确保 PYTHONPATH 包含 AngelSlim 根目录
+export PYTHONPATH=/path/to/AngelSlim:$PYTHONPATH
+```
+
+### 问题 2：vLLM 补丁未应用
+
+**症状**：`AttributeError: collect_fused_moe_internal_stats not found` 或 `VLLM_MOE_COLLECT_STATS environment variable not recognized`
+
+**解决方案**：
+
+```bash
+# 1. 检查补丁状态
+bash tools/vllm_patch/install.sh check
+
+# 2. 若检查失败，重新安装补丁
+bash tools/vllm_patch/install.sh uninstall
+bash tools/vllm_patch/install.sh install
+
+# 3. 若 Ray 集群已启动，需要在 worker 节点上也安装补丁
+# （在每个 worker 节点上运行）
+bash tools/vllm_patch/install.sh install
+```
+
+### 问题 3：OOM（内存溢出）
+
+**症状**：`CUDA out of memory` 或 `RuntimeError: CUDA memory`
+
+**解决方案**：
+
+```yaml
+# 在配置文件中减少以下参数
+batch_size: 2              # 从 4 减为 2
+max_length: 8192           # 从 16384 减为 8192
+num_samples: 256           # 从 512 减为 256
+
+# 对 Alpha 搜索也减少
+num_search_samples: 8      # 从 16 减为 8
+search_max_length: 4096    # 从 8192 减为 4096
+```
+
+### 问题 4：Phase 2 转换失败
+
+**症状**：`KeyError: 'model.layers.0.self_attn.q_proj' not found in smooth_stats.json`
+
+**解决方案**：
+
+```bash
+# 1. 检查 smooth_stats.json 文件是否存在且非空
+ls -la /path/to/output_dir/smooth_stats.json
+wc -l /path/to/output_dir/smooth_stats.json
+
+# 2. 查看 JSON 结构
+python3 -c "import json; f=json.load(open('/path/to/smooth_stats.json')); print(list(f.keys())[:5])"
+
+# 3. 检查配置中的 output_dir 是否正确
+grep "output_dir:" configs/hy3/ptq/hy3_smooth.yaml
+```
+
+### 问题 5：Alpha 搜索耗时过长
+
+**症状**：Phase 1 运行超过 10 小时仍未完成
+
+**解决方案**：
+
+```yaml
+# 减少搜索复杂度
+enable_alpha_search: false         # 暂时禁用搜索，仅收集统计
+# 或改用手工指定的 alpha 值
+
+# 若确实需要搜索，减少搜索参数
+alpha_steps: 4                     # 从 8 改为 4
+num_search_samples: 8              # 从 16 改为 8
+alpha_min: 0.4                     # 缩小搜索范围
+alpha_max: 0.8                     # 缩小搜索范围
+```
+
+---
+
+## 参考资源
+
+### 论文和文献
+
+- **SmoothQuant 原论文**：https://arxiv.org/abs/2211.10438
+  - 提出 Smooth 的核心思想和数学框架
+  
+- **GPTQ（含与 Smooth 的对比）**：https://arxiv.org/abs/2210.17323
+
+### 相关文档
+
+- [vLLM Smooth 补丁说明](../vllm_patch/README.md)
+- [KV-Cache 校准说明](../kvcache/README.md)
+- [主 PTQ 校准说明](../../scripts/ptq/README.md)
+- [AngelSlim 量化模块文档](../../angelslim/compressor/quant/)
+
+### 核心代码位置
+
+| 文件 | 功能 |
+| --- | --- |
+| `tools/smooth/run_vllm_smooth.py` | Phase 1 主程序（统计收集 + Alpha 搜索） |
+| `tools/smooth/convert_smooth_weights.py` | Phase 2 主程序（权重变换） |
+| `angelslim/compressor/quant/modules/smooth/smooth.py` | 核心 Smooth 算法实现 |
+| `angelslim/compressor/quant/core/vllm_calibrate_utils/` | 统计钩子 / Alpha 搜索实现 |
+| `configs/hy3/ptq/hy3_smooth.yaml` | HY3 默认配置 |
+
+### 快速命令参考
+
+```bash
+# 快速开始
+bash scripts/ptq/run_smooth_for_HY3.sh
+
+# 分步执行
+bash scripts/ptq/run_smooth_calibrate_for_HY3.sh   # Phase 1
+bash scripts/ptq/run_smooth_convert_for_HY3.sh     # Phase 2
+
+# 查看日志
+tail -f /path/to/output_dir/smooth_stats.json
+
+# 验证输出
+python3 -c "import json; print(json.load(open('/path/to/smooth_model/model.safetensors.metadata.json'))['_file_type'])"
+
+# 集成到量化流水线
+python3 tools/fp8_quant_with_vllm_activation.py --model-path /data/smooth_model ...
+```
+
+---
+
+## 常见问题（FAQ）
+
+**Q: Smooth 和 GPTQ 有什么区别？**
+
+A: Smooth 是一种"前处理"方法，在量化前对激活和权重分布进行缩放变换，提升量化友好性；而 GPTQ 是一种量化算法本身，通过海森矩阵进行逐层优化。两者可以互补：先用 Smooth 预处理，再用 GPTQ 量化。
+
+**Q: Alpha 应该如何选择？**
+
+A: 若启用 `enable_alpha_search: true`，系统会自动为每层搜索最优 alpha；否则使用手工指定的 `alpha_qk` / `alpha_vo` / `alpha_down`。通常推荐启用搜索以获得更好的精度。
+
+**Q: smooth_stats.json 可以手工编辑吗？**
+
+A: 可以。文件格式为标准 JSON，每层包含 `absmax` 和 `ema` 两个数组。若某层的统计不合理，可以手工修改后重跑 Phase 2。
+
+**Q: 如何应用 Smooth 到自己的模型？**
+
+A: 在 `configs/` 下创建模型特定配置文件，修改 `model_path`、`ptq_data_path`、`output_dir`、`save_path` 等路径，然后执行相应的脚本。详见"集成与扩展"章节。
+
+---
+
+**最后更新**：2026-05-26
+
+**维护者**：AngelSlim 开发团队
+
+**反馈**：若发现问题或有改进建议，欢迎提交 Issue 或 Pull Request。

--- a/tools/smooth/convert_smooth_weights.py
+++ b/tools/smooth/convert_smooth_weights.py
@@ -1,0 +1,1803 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Offline SmoothQuant weight conversion.
+
+Usage:
+    python convert_smooth_weights.py \
+        --model-path /path/to/model \
+        --smooth-stats /path/to/smooth_stats.json \
+        --save-path /path/to/output \
+        [--alpha-qk 0.6] [--alpha-vo 0.5] \
+        [--use-ema]
+
+Smooth stats JSON format (from run_vllm_smooth.py):
+    {
+      "<attn_layer>.q":        {"absmax": [...], "ema": [...], "call_count": N},
+      "<attn_layer>.k":        {...},
+      "<attn_layer>.attn_out": {...},
+      ...
+    }
+  where <attn_layer> is the vLLM Attention layer name,
+  e.g. "model.layers.0.self_attn.attn"
+"""
+
+import argparse
+import contextlib
+import inspect
+import json
+import math
+import os
+import shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Offline SmoothQuant weight conversion")
+    parser.add_argument(
+        "--model-path", type=str,
+        help="Path to the pretrained model directory (safetensors format)",
+    )
+    parser.add_argument(
+        "--smooth-stats", type=str, default=None,
+        help="Path to smooth stats JSON file. If not set, auto-detected from output-dir.",
+    )
+    parser.add_argument(
+        "--output-dir", type=str, default=None,
+        help="Directory containing smooth_stats.json and smooth_alpha_search.json "
+             "(output of run_vllm_smooth.py). Used for auto-detection when --smooth-stats is not set.",
+    )
+    parser.add_argument(
+        "--save-path", type=str,
+        help="Directory to save the transformed model",
+    )
+    parser.add_argument(
+        "--alpha-qk", type=float, default=0.6,
+        help="Alpha for QK smooth weight formula: smooth = k_absmax^alpha (default: 0.6)",
+    )
+    parser.add_argument(
+        "--alpha-vo", type=float, default=0.5,
+        help="Alpha for VO smooth: smooth = attn_out^alpha / o_proj_max^(1-alpha) (default: 0.5)",
+    )
+    parser.add_argument(
+        "--use-ema", action="store_true",
+        help="Use EMA stats instead of absmax for smooth weight computation",
+    )
+    parser.add_argument(
+        "--device", type=str, default="cpu",
+        help="Device to load the model on (default: cpu). Use 'cuda' or 'auto' for GPU.",
+    )
+    parser.add_argument(
+        "--dtype", type=str, default="auto",
+        choices=["auto", "float32", "float16", "bfloat16"],
+        help="Dtype to load the model in (default: auto)",
+    )
+    parser.add_argument(
+        "--smooth-qk", action="store_true",
+        help="Apply QK smooth (q_proj/k_proj weight transformation). "
+             "Requires attn.q and attn.k stats in smooth-stats.",
+    )
+    parser.add_argument(
+        "--smooth-vo", action="store_true",
+        help="Apply VO smooth (v_proj/o_proj weight transformation). "
+             "Requires attn_out stats in smooth-stats.",
+    )
+    parser.add_argument(
+        "--smooth-down", action="store_true",
+        help="Apply down_proj smooth (down_proj/up_proj weight transformation). "
+             "Requires down_proj stats in smooth-stats.",
+    )
+    parser.add_argument(
+        "--alpha-down", type=float, default=0.5,
+        help="Alpha for down_proj smooth: smooth = absmax^alpha / weight_absmax^(1-alpha) (default: 0.5)",
+    )
+    parser.add_argument(
+        "--enable-alpha-search", action="store_true",
+        help="Enable alpha search result loading. When set, auto-detects "
+             "smooth_alpha_search.json from output-dir. Per-key: if key has search "
+             "result, use precomputed smooth_weight; otherwise use --alpha-down.",
+    )
+    parser.add_argument(
+        "--alpha-search-results", type=str, default=None,
+        help="Path to smooth_alpha_search.json (output of alpha grid search). "
+             "When provided, down_proj smooth uses pre-computed smooth_weight "
+             "from search results instead of computing from smooth-stats + fixed alpha.",
+    )
+    parser.add_argument(
+        "--down-workers", type=int, default=128,
+        help="Number of parallel threads for down_proj smooth (default: 128). "
+             "Set to 1 to disable parallelism. Automatically disabled when accelerate hooks are detected.",
+    )
+    parser.add_argument(
+        "--save-workers", type=int, default=16,
+        help="Number of parallel threads for writing safetensors shards (default: 16). "
+             "Increase for fast NVMe/parallel NFS; each thread writes one shard file independently.",
+    )
+    parser.add_argument(
+        "--shard-size-gb", type=float, default=8.0,
+        help="Target size (GiB) of each safetensors shard file (default: 8.0).",
+    )
+    parser.add_argument(
+        "--patch-mlp-layers", type=int, default=3,
+        help="Number of MLP expert/share_expert Linear layers to patch for logit loss verification (default: 3)",
+    )
+    parser.add_argument(
+        "--verify-seq-len", type=int, default=8,
+        help="Sequence length for smooth verification forward passes (default: 8)",
+    )
+
+    # Architecture key map
+    parser.add_argument(
+        "--arch", type=str, default="hy_v3",
+        choices=list(PREDEFINED_KEY_MAPS.keys()) + ["custom"],
+        help="Architecture key map to use (default: hy_v3). "
+             "Use 'custom' with --key-map-file for user-defined mapping.",
+    )
+    parser.add_argument(
+        "--key-map-file", type=str, default=None,
+        help="Custom key_map JSON file path (used when --arch=custom).",
+    )
+
+    # YAML config support
+    parser.add_argument("-c", "--config", type=str, default=None,
+                        help="YAML config file path. Values override argparse defaults; "
+                             "explicit CLI flags still take final precedence.")
+
+    args = parser.parse_args()
+
+    # Lazy-import _yaml_args (located in tools/). Done here instead of at
+    # module top so flake8 doesn't trip on a sys.path mutation between
+    # imports.
+    import sys
+    _tools_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if _tools_dir not in sys.path:
+        sys.path.insert(0, _tools_dir)
+    from _yaml_args import apply_yaml_config
+    apply_yaml_config(parser, args)
+
+    # Auto-resolve smooth_stats path from output_dir
+    if args.smooth_stats is None and args.output_dir is not None:
+        args.smooth_stats = os.path.join(args.output_dir, "smooth_stats.json")
+
+    if args.smooth_stats is None:
+        parser.error("Either --smooth-stats or --output-dir must be specified.")
+
+    # Auto-resolve alpha_search_results from output_dir or enable_alpha_search
+    if args.alpha_search_results is None and args.enable_alpha_search:
+        if args.output_dir is not None:
+            candidate = os.path.join(args.output_dir, "smooth_alpha_search.json")
+            if os.path.isfile(candidate):
+                args.alpha_search_results = candidate
+
+    return args
+
+
+# ---------------------------------------------------------------------------
+# KEY_MAP
+# ---------------------------------------------------------------------------
+
+HY_V3_KEY_MAP = {
+    # projection 属性名
+    "q_proj": "q_proj",
+    "k_proj": "k_proj",
+    "v_proj": "v_proj",
+    "o_proj": "o_proj",
+    "down_proj": "down_proj",
+    "up_proj": "up_proj",
+
+    # qk_norm 相关
+    "qk_norm_flag": "use_qk_norm",
+    "q_norm": "q_norm",
+    "k_norm": "k_norm",
+
+    # stats key 后缀
+    "stat_k": ".k",
+    "stat_q": ".q",
+    "stat_attn_out": ".attn_out",
+
+    # vLLM -> HF 路径转换
+    "attn_strip": ".attn",
+
+    # down_proj stat 匹配模式
+    "down_patterns": [
+        r"\.shared_mlp\.down_proj",
+        r"\.mlp\.down_proj",
+        r"\.experts\.\d+\.down_proj",
+    ],
+
+    # 验证用 MLP container 匹配
+    "mlp_containers": [
+        r"mlp\.shared_mlp$",
+        r"mlp\.experts\.\d+$",
+    ],
+}
+
+LLAMA_KEY_MAP = {
+    "q_proj": "q_proj",
+    "k_proj": "k_proj",
+    "v_proj": "v_proj",
+    "o_proj": "o_proj",
+    "down_proj": "down_proj",
+    "up_proj": "up_proj",
+
+    "qk_norm_flag": "use_qk_norm",
+    "q_norm": "q_norm",
+    "k_norm": "k_norm",
+
+    "stat_k": ".k",
+    "stat_q": ".q",
+    "stat_attn_out": ".attn_out",
+    "attn_strip": ".attn",
+
+    "down_patterns": [r"\.mlp\.down_proj"],
+    "mlp_containers": [r"mlp$"],
+}
+
+MIXTRAL_KEY_MAP = {
+    "q_proj": "q_proj",
+    "k_proj": "k_proj",
+    "v_proj": "v_proj",
+    "o_proj": "o_proj",
+    "down_proj": "w2",
+    "up_proj": "w3",
+
+    "qk_norm_flag": "use_qk_norm",
+    "q_norm": "q_norm",
+    "k_norm": "k_norm",
+
+    "stat_k": ".k",
+    "stat_q": ".q",
+    "stat_attn_out": ".attn_out",
+    "attn_strip": ".attn",
+
+    "down_patterns": [r"\.block_sparse_moe\.experts\.\d+\.w2"],
+    "mlp_containers": [r"block_sparse_moe\.experts\.\d+$"],
+}
+
+PREDEFINED_KEY_MAPS = {
+    "hy_v3": HY_V3_KEY_MAP,
+    "llama": LLAMA_KEY_MAP,
+    "mixtral": MIXTRAL_KEY_MAP,
+}
+
+DEFAULT_KEY_MAP = HY_V3_KEY_MAP
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def load_smooth_stats(json_path: str, use_ema: bool = False) -> dict:
+    """
+    Load smooth stats from JSON file and convert lists back to tensors.
+
+    Returns dict keyed by layer-tag string, e.g. "model.layers.0.self_attn.attn.k",
+    with values {"scale": Tensor[D], "call_count": int}.
+    The "scale" field is taken from "ema" if use_ema else "absmax".
+    """
+    with open(json_path, "r") as f:
+        raw = json.load(f)
+
+    stats = {}
+    for key, val in raw.items():
+        field = "ema" if use_ema else "absmax"
+        data = val.get(field)
+        if data is None:
+            data = val.get("absmax")   # fallback to absmax
+        stats[key] = {
+            "scale": torch.tensor(data, dtype=torch.float32) if data is not None else None,
+            "call_count": val.get("call_count", 0),
+        }
+    return stats
+
+
+def attn_key_to_hf_prefix(smooth_key_base: str, km: dict = None) -> str:
+    """
+    Map vLLM Attention layer name to HuggingFace module prefix.
+
+    vLLM wraps the raw attention op in a sub-module ".attn", so:
+      "model.layers.0.self_attn.attn"  ->  "model.layers.0.self_attn"
+
+    If the key does not end with the attn_strip suffix we return it unchanged (fallback).
+    """
+    km = km or DEFAULT_KEY_MAP
+    attn_strip = km["attn_strip"]
+    if smooth_key_base.endswith(attn_strip):
+        return smooth_key_base[:-len(attn_strip)]
+    return smooth_key_base
+
+
+def get_submodule_safe(model: torch.nn.Module, name: str):
+    """Return a nested submodule by dotted name, or None if not found."""
+    try:
+        return model.get_submodule(name)
+    except AttributeError:
+        return None
+
+
+@contextlib.contextmanager
+def _maybe_materialize(linear: torch.nn.Module, target_device):
+    """
+    Context manager that temporarily materializes meta-device weights for
+    in-place modification, then offloads them back via accelerate hooks.
+
+    If the linear layer has no accelerate hook or weights are not on meta
+    device, this is a no-op and the caller can modify weights directly.
+
+    Usage:
+        with _maybe_materialize(proj, device):
+            proj.weight.data.mul_(scale)
+    """
+    hook = getattr(linear, "_hf_hook", None)
+    if hook is not None and linear.weight.device.type == "meta":
+        original_exec_device = hook.execution_device
+        hook.execution_device = target_device
+        hook.pre_forward(linear)
+        try:
+            yield
+        finally:
+            hook.post_forward(linear, None)
+            hook.execution_device = original_exec_device
+    else:
+        yield
+
+
+# ---------------------------------------------------------------------------
+# High-precision weight update helpers
+# ---------------------------------------------------------------------------
+
+def _inplace_mul_fp32(weight: torch.Tensor, scale: torch.Tensor) -> None:
+    """weight *= scale, computed in float32 then cast back to original dtype."""
+    orig_dtype = weight.dtype
+    weight.data.copy_(weight.data.float().mul_(scale.float()).to(orig_dtype))
+
+
+def _inplace_div_fp32(weight: torch.Tensor, scale: torch.Tensor) -> None:
+    """weight /= scale, computed in float32 then cast back to original dtype."""
+    orig_dtype = weight.dtype
+    weight.data.copy_(weight.data.float().div_(scale.float()).to(orig_dtype))
+
+
+# ---------------------------------------------------------------------------
+# Output diff verification
+# ---------------------------------------------------------------------------
+
+def _find_first_attn_module(model: torch.nn.Module, smooth_stats: dict, km: dict = None):
+    """
+    Find the first self_attn submodule that exists in both model and smooth_stats.
+
+    Returns:
+        (hf_prefix, attn_module) or (None, None)
+    """
+    km = km or DEFAULT_KEY_MAP
+    stat_k = km["stat_k"]
+    stat_attn_out = km["stat_attn_out"]
+
+    bases = set()
+    for key in smooth_stats:
+        if key.endswith(stat_k):
+            bases.add(key[:-len(stat_k)])
+        elif key.endswith(stat_attn_out):
+            bases.add(key[:-len(stat_attn_out)])
+
+    for base in sorted(bases):
+        hf_prefix   = attn_key_to_hf_prefix(base, km)
+        attn_module = get_submodule_safe(model, hf_prefix)
+        if attn_module is None:
+            continue
+        if all(getattr(attn_module, km[p], None) is not None
+               for p in ("q_proj", "k_proj", "v_proj", "o_proj")):
+            return hf_prefix, attn_module
+
+    return None, None
+
+
+def _run_attn_forward(
+    attn_module,
+    hidden_states: torch.Tensor,
+    rope_cache=None,
+) -> torch.Tensor:
+    """
+    Run self_attn forward, using inspect to detect accepted parameters.
+
+    hidden_states shape: (1, seq_len, hidden_size)  (batch=1)
+
+    Returns:
+        output tensor (1, seq_len, hidden_size), detached on cpu in float32
+    """
+    seq_len = hidden_states.shape[1]
+    device  = hidden_states.device
+    position_ids = torch.arange(seq_len, dtype=torch.long, device=device).unsqueeze(0)
+    cache_pos    = torch.arange(seq_len, dtype=torch.long, device=device)
+
+    # Construct position_embeddings (cos, sin) tuple for newer model architectures
+    position_embeddings = None
+    if rope_cache is not None:
+        _head_dim = rope_cache.shape[-1] // 2
+        cos_part = rope_cache[:seq_len, :_head_dim].unsqueeze(0).to(
+            dtype=hidden_states.dtype, device=device
+        )
+        sin_part = rope_cache[:seq_len, _head_dim:].unsqueeze(0).to(
+            dtype=hidden_states.dtype, device=device
+        )
+        position_embeddings = (cos_part, sin_part)
+
+    all_kwargs = dict(
+        hidden_states    = hidden_states,
+        attention_mask   = None,
+        position_ids     = position_ids,
+        position_embeddings = position_embeddings,
+        rope_cache       = rope_cache,
+        past_key_value   = None,
+        output_attentions= False,
+        use_cache        = False,
+        cache_position   = cache_pos,
+    )
+
+    try:
+        sig    = inspect.signature(attn_module.forward)
+        params = sig.parameters
+        has_var_keyword = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+        )
+        if has_var_keyword:
+            kwargs = all_kwargs
+        else:
+            kwargs = {k: v for k, v in all_kwargs.items() if k in params}
+    except (ValueError, TypeError):
+        kwargs = all_kwargs
+
+    cfg = getattr(attn_module, "config", None)
+    orig_attn_impl = getattr(cfg, "_attn_implementation", None) if cfg else None
+    if orig_attn_impl not in (None, "eager", "flash_attention_2"):
+        cfg._attn_implementation = "eager"
+
+    try:
+        out = attn_module(**kwargs)
+    finally:
+        if orig_attn_impl is not None and cfg is not None:
+            cfg._attn_implementation = orig_attn_impl
+
+    result = out[0] if isinstance(out, (tuple, list)) else out
+    return result.detach().cpu().float()
+
+
+def snapshot_attn_output_before(
+    model: torch.nn.Module,
+    smooth_stats: dict,
+    seq_len: int = 8,
+    seed: int = 42,
+    km: dict = None,
+) -> dict | None:
+    """
+    Record attn forward output BEFORE smooth transformation for verification.
+
+    Returns:
+        dict with keys: hf_prefix, x (input), out_before (output tensor)
+        or None if no suitable layer found.
+    """
+    km = km or DEFAULT_KEY_MAP
+    hf_prefix, attn_module = _find_first_attn_module(model, smooth_stats, km)
+    if attn_module is None:
+        print("  [Verify] No suitable attn layer found, skipping verification")
+        return None
+
+    weight       = getattr(attn_module, km["q_proj"]).weight
+    hidden_size  = weight.shape[1]
+    model_dtype  = weight.dtype
+    model_device = weight.device
+
+    cfg       = model.config
+    _head_dim = getattr(cfg, "head_dim", None) or (cfg.hidden_size // cfg.num_attention_heads)
+    _max_seq  = getattr(cfg, "max_position_embeddings", 4096)
+    _base     = getattr(cfg, "rope_theta", 10000.0)
+    freqs     = 1.0 / (_base ** (
+        torch.arange(0, _head_dim, 2, dtype=torch.float32, device=model_device)[:(_head_dim // 2)] / _head_dim
+    ))
+    t         = torch.arange(_max_seq, dtype=freqs.dtype, device=model_device)
+    idx_theta = torch.outer(t, freqs)
+    freqs_cat = torch.cat([idx_theta, idx_theta], dim=-1)
+    rope_cache = torch.cat([freqs_cat.cos(), freqs_cat.sin()], dim=-1)
+    print(f"  [Verify] Generated rope_cache: shape={list(rope_cache.shape)}, "
+          f"head_dim={_head_dim}, base={_base}, device={model_device}")
+
+    torch.manual_seed(seed)
+    x = torch.randn(1, seq_len, hidden_size, dtype=model_dtype, device=model_device)
+
+    print(
+        f"\n[Verify] Recording pre-transform output -> layer={hf_prefix}, "
+        f"input shape={list(x.shape)}, dtype={model_dtype}, device={model_device}, seed={seed}"
+    )
+
+    with torch.no_grad():
+        out_before = _run_attn_forward(attn_module, x, rope_cache=rope_cache)
+
+    return {
+        "hf_prefix":  hf_prefix,
+        "x":          x,
+        "out_before": out_before,
+        "rope_cache": rope_cache,
+        "seed":       seed,
+    }
+
+
+def verify_attn_output_diff(
+    snap: dict | None,
+    model: torch.nn.Module,
+    atol: float = 1e-3,
+    rtol: float = 1e-3,
+    km: dict = None,
+) -> None:
+    """
+    Compare attn forward output before and after smooth transformation.
+    """
+    km = km or DEFAULT_KEY_MAP
+    print("\n" + "=" * 70)
+    print("[Verify] Attention output diff (before vs after transform)")
+
+    if snap is None:
+        print("  Skipped: no snapshot available")
+        print("=" * 70)
+        return
+
+    hf_prefix   = snap["hf_prefix"]
+    attn_module = get_submodule_safe(model, hf_prefix)
+    if attn_module is None:
+        print(f"  Skipped: module {hf_prefix} not found after transform")
+        print("=" * 70)
+        return
+
+    if getattr(attn_module, km["qk_norm_flag"], False) or getattr(model.config, "qk_norm", False):
+        print(f"  [NOTE] {hf_prefix} has qk_norm=True, QK smooth was skipped, expect equivalent output")
+
+    x          = snap["x"]
+    out_before = snap["out_before"]
+    rope_cache = snap.get("rope_cache")
+
+    with torch.no_grad():
+        out_after = _run_attn_forward(attn_module, x, rope_cache=rope_cache)
+
+    diff     = (out_after - out_before).abs()
+    max_diff  = diff.max().item()
+    mean_diff = diff.mean().item()
+    rel_max   = (diff / out_before.abs().clamp(min=1e-8)).max().item()
+    is_close  = torch.allclose(out_before, out_after, atol=atol, rtol=rtol)
+
+    print(f"  Layer        : {hf_prefix}")
+    print(f"  Input shape  : {list(x.shape)}  (seed={snap['seed']})")
+    print(f"  Output shape : {list(out_before.shape)}")
+    print(f"  max  |diff|  : {max_diff:.6e}")
+    print(f"  mean |diff|  : {mean_diff:.6e}")
+    print(f"  max rel diff : {rel_max:.6e}")
+    print(
+        f"  allclose(atol={atol}, rtol={rtol}): "
+        f"{'PASS' if is_close else 'FAIL'}"
+    )
+
+    if not is_close:
+        flat_diff = diff.reshape(-1)
+        topk_vals, topk_idx = flat_diff.topk(min(5, flat_diff.numel()))
+        print("  Top-5 largest diff positions (flat index):")
+        for rank, (idx, val) in enumerate(zip(topk_idx.tolist(), topk_vals.tolist()), 1):
+            b_val = out_before.reshape(-1)[idx].item()
+            a_val = out_after.reshape(-1)[idx].item()
+            print(f"    #{rank}  idx={idx:6d}  before={b_val:+.6f}  after={a_val:+.6f}  diff={val:.6e}")
+
+    print("=" * 70)
+
+
+# ---------------------------------------------------------------------------
+# MLP layer patch + logit-loss verification
+# ---------------------------------------------------------------------------
+
+def _collect_mlp_linears(model: torch.nn.Module, max_layers: int, km: dict = None) -> list[tuple[str, torch.nn.Module]]:
+    """
+    Collect MLP container modules for verification, matching patterns from key_map.
+    """
+    import re
+    km = km or DEFAULT_KEY_MAP
+    _container_patterns = [re.compile(p) for p in km["mlp_containers"]]
+
+    seen: set[str] = set()
+    results: list[tuple[str, torch.nn.Module]] = []
+
+    def _add(name: str, mod) -> bool:
+        if name not in seen:
+            seen.add(name)
+            results.append((name, mod))
+            print(f"  [Verify] Collected MLP container: {name}")
+        return len(results) >= max_layers
+
+    for pat in _container_patterns:
+        cnt = 0
+        for name, mod in model.named_modules():
+            if pat.search(name):
+                cnt += 1
+                _add(name, mod)
+                if cnt >= max_layers:
+                    break
+
+    return results
+
+
+@contextlib.contextmanager
+def _force_eager_attn(model: torch.nn.Module):
+    """Temporarily switch _attn_implementation to eager for verification."""
+    cfg = getattr(model, "config", None)
+    orig = getattr(cfg, "_attn_implementation", None) if cfg is not None else None
+    if cfg is not None and orig not in (None, "eager", "flash_attention_2"):
+        cfg._attn_implementation = "eager"
+    try:
+        yield
+    finally:
+        if cfg is not None and orig is not None:
+            cfg._attn_implementation = orig
+
+
+def _run_module_forward(mod: torch.nn.Module, x: torch.Tensor) -> torch.Tensor:
+    """Forward a single module, return first output tensor (float32, cpu)."""
+    with torch.no_grad():
+        out = mod(x)
+    if isinstance(out, (tuple, list)):
+        out = out[0]
+    return out.detach().cpu().float()
+
+
+def snapshot_mlp_outputs_before(
+    model: torch.nn.Module,
+    patch_n: int = 3,
+    seq_len: int = 8,
+    seed: int = 42,
+    km: dict = None,
+) -> list[dict]:
+    """
+    Collect MLP modules and record their pre-transform forward output.
+    """
+    km = km or DEFAULT_KEY_MAP
+    mlp_mods = _collect_mlp_linears(model, patch_n, km)
+    if not mlp_mods:
+        print("[Verify MLP] No MLP modules found, skipping.")
+        return []
+
+    rng = torch.Generator()
+    rng.manual_seed(seed)
+    snap = []
+    for name, mod in mlp_mods:
+        hidden = None
+        if isinstance(mod, torch.nn.Linear):
+            hidden = mod.in_features
+        else:
+            for sub in mod.modules():
+                if isinstance(sub, torch.nn.Linear):
+                    hidden = sub.in_features
+                    break
+        if hidden is None:
+            print(f"  [Verify MLP] Cannot infer hidden_size for {name}, skipping.")
+            continue
+
+        try:
+            p = next(mod.parameters())
+            dev, dt = p.device, p.dtype
+        except StopIteration:
+            dev, dt = torch.device("cpu"), torch.float32
+
+        x = torch.randn(1, seq_len, hidden, generator=rng, dtype=dt, device=dev)
+        out_before = _run_module_forward(mod, x)
+        snap.append({"name": name, "mod": mod, "x": x, "out_before": out_before})
+        print(f"  [Verify MLP] Recorded pre-transform output: {name}  shape={out_before.shape}")
+
+    return snap
+
+
+def verify_mlp_output_diff(
+    snap: list[dict],
+    atol: float = 1e-2,
+    rtol: float = 1e-2,
+) -> None:
+    """Compare MLP module output before and after transformation."""
+    if not snap:
+        print("[Verify MLP] No snapshot, skipping.")
+        return
+
+    print("\n[Verify MLP] MLP module output comparison (before vs after):")
+    all_pass = True
+    for entry in snap:
+        name = entry["name"]
+        mod = entry["mod"]
+        x = entry["x"]
+        out_before = entry["out_before"]
+
+        out_after = _run_module_forward(mod, x)
+        diff = (out_after - out_before).abs()
+        max_err = diff.max().item()
+        mse = (diff ** 2).mean().sqrt().item()
+        ok = max_err <= atol + rtol * out_before.abs().max().item()
+        status = "PASS" if ok else "FAIL"
+        if not ok:
+            all_pass = False
+        print(f"  {status} {name:60s}  max_abs_err={max_err:.4e}  rmse={mse:.4e}")
+
+    if all_pass:
+        print("[Verify MLP] All MLP modules within tolerance. PASS")
+    else:
+        print("[Verify MLP] Some MLP modules exceed tolerance! FAIL")
+
+
+# ---------------------------------------------------------------------------
+# QK smooth
+# ---------------------------------------------------------------------------
+
+def apply_qk_smooth(
+    model: torch.nn.Module,
+    smooth_stats: dict,
+    alpha: float = 0.6,
+    head_dim: int = None,
+    km: dict = None,
+) -> None:
+    """
+    Apply QK smooth to every layer that has both attn.k and attn.q stats.
+
+    Smooth weight formula (RoPE-aware pairing):
+        k_absmax reshape -> [num_kv_heads, head_dim]
+        paired[h, d] = max(k_absmax[h, d], k_absmax[h, d + head_dim/2])
+        smooth_weight[h, d] = smooth_weight[h, d + head_dim/2] = paired[h, d] ^ alpha
+
+    GQA handling: expand smooth_weight from kv_heads to q_heads via repeat_interleave.
+
+    qk_norm path: fuse smooth into q_norm/k_norm weights instead of proj weights.
+    """
+    km = km or DEFAULT_KEY_MAP
+    stat_k = km["stat_k"]
+    stat_q = km["stat_q"]
+
+    k_keys = {k for k in smooth_stats if k.endswith(stat_k)}
+    q_keys = {k for k in smooth_stats if k.endswith(stat_q)}
+    k_bases = {k[:-len(stat_k)] for k in k_keys}
+    q_bases = {k[:-len(stat_q)] for k in q_keys}
+    valid_bases = k_bases & q_bases
+
+    print(f"\n[QK Smooth] {len(valid_bases)} layers eligible (have both attn.k and attn.q stats)")
+
+    for base in sorted(valid_bases):
+        k_stat_key = base + stat_k
+        hf_prefix  = attn_key_to_hf_prefix(base, km)
+
+        attn_module = get_submodule_safe(model, hf_prefix)
+        if attn_module is None:
+            print(f"  [SKIP] {hf_prefix}: module not found in model")
+            continue
+
+        use_qk_norm = getattr(attn_module, km["qk_norm_flag"], False) or getattr(model.config, "qk_norm", False)
+        q_norm = getattr(attn_module, km["q_norm"], None) if use_qk_norm else None
+        k_norm = getattr(attn_module, km["k_norm"], None) if use_qk_norm else None
+        if use_qk_norm and (q_norm is None or k_norm is None):
+            print(f"  [SKIP] {hf_prefix}: use_qk_norm=True but q_norm/k_norm not found")
+            continue
+
+        q_proj = getattr(attn_module, km["q_proj"], None)
+        k_proj = getattr(attn_module, km["k_proj"], None)
+        if q_proj is None or k_proj is None:
+            print(f"  [SKIP] {hf_prefix}: q_proj or k_proj not found")
+            continue
+
+        k_scale = smooth_stats[k_stat_key]["scale"]
+        if k_scale is None:
+            print(f"  [SKIP] {hf_prefix}: k scale is None")
+            continue
+
+        k_absmax   = k_scale.to(torch.float32)
+        D          = k_absmax.shape[0]
+
+        if head_dim is None:
+            raise ValueError(f"head_dim must be provided for QK smooth (layer {hf_prefix})")
+
+        num_kv_heads_loc = D // head_dim
+        half_hd          = head_dim // 2
+
+        k_per_head  = k_absmax.reshape(num_kv_heads_loc, head_dim)
+        paired_hd   = torch.maximum(
+            k_per_head[:, :half_hd], k_per_head[:, half_hd:]
+        ).clamp(min=1e-8)
+        smooth_per_head              = torch.empty(num_kv_heads_loc, head_dim, dtype=torch.float32)
+        smooth_per_head[:, :half_hd] = paired_hd
+        smooth_per_head[:, half_hd:] = paired_hd
+        smooth_weight                = smooth_per_head.pow(alpha)
+
+        q_out_dim = q_proj.weight.shape[0]
+        k_out_dim = k_proj.weight.shape[0]
+        is_gqa    = (q_out_dim != k_out_dim)
+        device    = q_proj.weight.device if not q_proj.weight.is_meta else torch.device("cpu")
+
+        if use_qk_norm:
+            per_dim_max = smooth_weight.max(dim=0).values
+            norm_sw     = torch.maximum(
+                per_dim_max[:half_hd], per_dim_max[half_hd:]
+            )
+            norm_smooth_weight              = torch.empty(head_dim, dtype=torch.float32)
+            norm_smooth_weight[:half_hd]    = norm_sw
+            norm_smooth_weight[half_hd:]    = norm_sw
+
+            norm_smooth_weight = norm_smooth_weight.to(device=device)
+
+            with _maybe_materialize(q_norm, device):
+                _inplace_mul_fp32(q_norm.weight, norm_smooth_weight)
+            with _maybe_materialize(k_norm, device):
+                _inplace_div_fp32(k_norm.weight, norm_smooth_weight)
+
+            print(
+                f"  [QK-norm] {hf_prefix}: q_out={q_out_dim}, k_out={k_out_dim}, "
+                f"norm_smooth range=[{norm_smooth_weight.float().min():.4f}, {norm_smooth_weight.float().max():.4f}], "
+                f"gqa={'yes (n_groups=' + str(q_out_dim // k_out_dim) + ')' if is_gqa else 'no'}"
+            )
+
+        else:
+            smooth_weight_flat = smooth_weight.reshape(D)
+
+            if is_gqa:
+                num_kv_heads = k_out_dim // head_dim
+                n_groups     = q_out_dim // k_out_dim
+                sw_kv        = smooth_weight_flat.reshape(num_kv_heads, head_dim)
+                sw_q         = sw_kv.repeat_interleave(n_groups, dim=0)
+                q_smooth_weight = sw_q.reshape(q_out_dim)
+                smooth_k_weight = smooth_weight_flat
+            else:
+                q_smooth_weight = smooth_weight_flat
+                smooth_k_weight = smooth_weight_flat
+
+            q_smooth_weight = q_smooth_weight.to(device=device)
+            smooth_k_weight = smooth_k_weight.to(device=device)
+
+            with _maybe_materialize(q_proj, device):
+                _inplace_mul_fp32(q_proj.weight, q_smooth_weight.view(-1, 1))
+                if q_proj.bias is not None:
+                    _inplace_mul_fp32(q_proj.bias, q_smooth_weight)
+
+            with _maybe_materialize(k_proj, device):
+                _inplace_div_fp32(k_proj.weight, smooth_k_weight.view(-1, 1))
+                if k_proj.bias is not None:
+                    _inplace_div_fp32(k_proj.bias, smooth_k_weight)
+
+            print(
+                f"  [QK] {hf_prefix}: q_out={q_out_dim}, k_out={k_out_dim}, "
+                f"gqa={'yes (n_groups=' + str(q_out_dim // k_out_dim) + ')' if is_gqa else 'no'}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# VO smooth
+# ---------------------------------------------------------------------------
+
+def apply_vo_smooth(
+    model: torch.nn.Module,
+    smooth_stats: dict,
+    alpha: float = 0.5,
+    head_dim: int = None,
+    km: dict = None,
+) -> None:
+    """
+    Apply VO smooth to every layer that has attn_out stats.
+
+    Smooth weight formula:
+        smooth_weight[i] = attn_out_absmax[i]^alpha / max|o_proj.weight[:,i]|^(1-alpha)
+
+    GQA: max-pool smooth_weight across groups for v_proj.
+    """
+    km = km or DEFAULT_KEY_MAP
+    stat_attn_out = km["stat_attn_out"]
+
+    attn_out_keys = [k for k in smooth_stats if k.endswith(stat_attn_out)]
+    print(f"\n[VO Smooth] {len(attn_out_keys)} layers with attn_out stats")
+
+    for attn_out_key in sorted(attn_out_keys):
+        base       = attn_out_key[:-len(stat_attn_out)]
+        hf_prefix  = attn_key_to_hf_prefix(base, km)
+
+        attn_module = get_submodule_safe(model, hf_prefix)
+        if attn_module is None:
+            print(f"  [SKIP] {hf_prefix}: module not found in model")
+            continue
+
+        v_proj = getattr(attn_module, km["v_proj"], None)
+        o_proj = getattr(attn_module, km["o_proj"], None)
+        if v_proj is None or o_proj is None:
+            print(f"  [SKIP] {hf_prefix}: v_proj or o_proj not found")
+            continue
+
+        attn_out_scale = smooth_stats[attn_out_key]["scale"]
+        if attn_out_scale is None:
+            print(f"  [SKIP] {hf_prefix}: attn_out scale is None")
+            continue
+
+        attn_out_absmax = attn_out_scale.to(torch.float32).clamp(min=1e-8)
+        attn_out_dim    = attn_out_absmax.shape[0]
+
+        o_hook = getattr(o_proj, "_hf_hook", None)
+        if o_hook is not None and o_proj.weight.device.type == "meta":
+            _tmp_device = torch.device("cpu")
+            _orig_exec = o_hook.execution_device
+            o_hook.execution_device = _tmp_device
+            o_hook.pre_forward(o_proj)
+            o_proj_max = (
+                o_proj.weight.detach().float().abs().max(dim=0).values
+            ).clamp(min=1e-8)
+            o_hook.post_forward(o_proj, None)
+            o_hook.execution_device = _orig_exec
+        else:
+            o_proj_max = (
+                o_proj.weight.detach().float().abs().max(dim=0).values
+            ).clamp(min=1e-8)
+
+        smooth_weight = attn_out_absmax.pow(alpha) / o_proj_max.pow(1.0 - alpha)
+
+        v_out_dim = v_proj.weight.shape[0]
+        is_gqa    = (v_out_dim != attn_out_dim)
+
+        if is_gqa:
+            assert attn_out_dim % v_out_dim == 0, (
+                f"{hf_prefix}: attn_out_dim={attn_out_dim} not divisible by v_out_dim={v_out_dim}"
+            )
+            n_groups = attn_out_dim // v_out_dim
+
+            if head_dim is None:
+                raise ValueError(
+                    f"head_dim must be provided for GQA VO smooth (layer {hf_prefix})"
+                )
+            num_kv_heads = v_out_dim // head_dim
+
+            sw_grouped      = smooth_weight.reshape(num_kv_heads, n_groups, head_dim)
+            pooled          = sw_grouped.max(dim=1).values
+            smooth_v_weight = pooled.reshape(v_out_dim)
+
+            smooth_weight = (
+                pooled.unsqueeze(1)
+                       .expand(num_kv_heads, n_groups, head_dim)
+                       .reshape(attn_out_dim)
+            )
+        else:
+            smooth_v_weight = smooth_weight
+
+        device = v_proj.weight.device if not v_proj.weight.is_meta else torch.device("cpu")
+        smooth_v_weight = smooth_v_weight.to(device=device)
+        smooth_weight   = smooth_weight.to(device=device)
+
+        with _maybe_materialize(v_proj, device):
+            _inplace_div_fp32(v_proj.weight, smooth_v_weight.view(-1, 1))
+            if v_proj.bias is not None:
+                _inplace_div_fp32(v_proj.bias, smooth_v_weight)
+
+        with _maybe_materialize(o_proj, device):
+            _inplace_mul_fp32(o_proj.weight, smooth_weight.view(1, -1))
+
+        print(
+            f"  [VO] {hf_prefix}: v_out={v_out_dim}, attn_out={attn_out_dim}, "
+            f"gqa={'yes (n_groups=' + str(attn_out_dim // v_out_dim) + ')' if is_gqa else 'no'}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# down_proj smooth
+# ---------------------------------------------------------------------------
+
+def apply_down_proj_smooth(
+    model: torch.nn.Module,
+    smooth_stats: dict,
+    alpha: float = 0.5,
+    num_workers: int = 8,
+    exclude_keys: set | None = None,
+    km: dict = None,
+) -> None:
+    """
+    Apply down_proj smooth to every layer that has down_proj stats.
+
+    Key matching: stats keys that match patterns from key_map["down_patterns"].
+
+    Smooth weight formula:
+        smooth_weight = absmax^alpha / weight_absmax^(1-alpha)
+
+    Application:
+        down_proj.weight *= smooth_weight   (per input channel, dim=1)
+        up_proj.weight   /= smooth_weight   (per output channel, dim=0)
+
+    Parallelism:
+        Uses ThreadPoolExecutor. Falls back to serial if accelerate hooks detected.
+    """
+    import re as _re
+
+    km = km or DEFAULT_KEY_MAP
+    down_name = km["down_proj"]
+    up_name = km["up_proj"]
+
+    _DOWN_PATTERNS = [_re.compile(p) for p in km["down_patterns"]]
+
+    down_keys = [
+        k for k in smooth_stats
+        if any(pat.search(k) for pat in _DOWN_PATTERNS)
+    ]
+
+    # Filter out keys already handled by alpha search
+    if exclude_keys:
+        before = len(down_keys)
+        down_keys = [k for k in down_keys if k not in exclude_keys]
+        skipped = before - len(down_keys)
+        if skipped > 0:
+            print(f"  [Down Smooth] Skipped {skipped} keys already handled by alpha search")
+
+    print(f"\n[Down Smooth] {len(down_keys)} down_proj stat entries to process (fixed alpha={alpha})")
+
+    if not down_keys:
+        print("  [SKIP] No down_proj stats found in smooth-stats")
+        return
+
+    # Build named_modules dict and O(1) up_proj lookup table
+    all_named_modules: dict = {name: mod for name, mod in model.named_modules()}
+
+    up_proj_map: dict = {}
+    for name in all_named_modules:
+        if name.endswith("." + up_name):
+            parent = name[:-(len(up_name) + 1)]
+            up_proj_map[parent] = name
+
+    # Detect accelerate hooks -> fall back to serial for thread safety
+    has_hf_hook = any(
+        getattr(mod, "_hf_hook", None) is not None
+        for mod in all_named_modules.values()
+    )
+    effective_workers = 1 if has_hf_hook else num_workers
+    if has_hf_hook and num_workers > 1:
+        print(f"  [Parallel] accelerate _hf_hook detected -> fallback to serial (num_workers=1)")
+    else:
+        print(f"  [Parallel] num_workers={effective_workers}")
+
+    def _process_one(stat_key: str) -> None:
+        """Process a single down_proj stat_key (thread-safe, independent per key)."""
+        down_proj_module = get_submodule_safe(model, stat_key)
+        if down_proj_module is None:
+            matched_name = None
+            for name in all_named_modules:
+                if name.endswith(stat_key) or stat_key.endswith(name):
+                    matched_name = name
+                    break
+            if matched_name is None:
+                print(f"  [SKIP] {stat_key}: cannot locate down_proj module in model")
+                return
+            down_proj_module_name = matched_name
+        else:
+            down_proj_module_name = stat_key
+
+        down_proj_module = get_submodule_safe(model, down_proj_module_name)
+        if down_proj_module is None:
+            print(f"  [SKIP] {stat_key}: module {down_proj_module_name} not found")
+            return
+
+        if not hasattr(down_proj_module, "weight"):
+            print(f"  [SKIP] {down_proj_module_name}: no weight attribute (not a Linear?)")
+            return
+
+        # Find matching up_proj via O(1) hash-table lookup
+        parent = down_proj_module_name[:-(len(down_name) + 1)]
+        up_proj_name = up_proj_map.get(parent)
+        if up_proj_name is None:
+            print(f"  [SKIP] {down_proj_module_name}: cannot find matching up_proj")
+            return
+
+        up_proj_module = get_submodule_safe(model, up_proj_name)
+        if up_proj_module is None or not hasattr(up_proj_module, "weight"):
+            print(f"  [SKIP] {down_proj_module_name}: up_proj {up_proj_name} not usable")
+            return
+
+        scale = smooth_stats[stat_key]["scale"]
+        if scale is None:
+            print(f"  [SKIP] {down_proj_module_name}: scale is None")
+            return
+
+        raw = scale.to(torch.float32)
+
+        # Validate: skip layer if contains -inf, nan, or <=0 values
+        if torch.any(~torch.isfinite(raw)) or torch.any(raw <= 0):
+            n_neginf = torch.sum(torch.isneginf(raw)).item()
+            n_nan    = torch.sum(torch.isnan(raw)).item()
+            n_nonpos = torch.sum(raw <= 0).item()
+            print(
+                f"  [SKIP] {down_proj_module_name}: invalid scale values "
+                f"(-inf={n_neginf}, nan={n_nan}, <=0={n_nonpos}), skipping this layer"
+            )
+            return
+
+        absmax = raw.clamp(min=1e-8)
+
+        device = (
+            down_proj_module.weight.device
+            if not down_proj_module.weight.is_meta
+            else torch.device("cpu")
+        )
+
+        # Handle meta device for weight_absmax computation
+        d_hook = getattr(down_proj_module, "_hf_hook", None)
+        if d_hook is not None and down_proj_module.weight.device.type == "meta":
+            _tmp_device = torch.device("cpu")
+            _orig_exec  = d_hook.execution_device
+            d_hook.execution_device = _tmp_device
+            d_hook.pre_forward(down_proj_module)
+            weight_absmax = (
+                down_proj_module.weight.detach().float().abs().max(dim=0).values
+            ).clamp(min=1e-8)
+            d_hook.post_forward(down_proj_module, None)
+            d_hook.execution_device = _orig_exec
+        else:
+            weight_absmax = (
+                down_proj_module.weight.detach().float().abs().max(dim=0).values
+            ).clamp(min=1e-8)
+
+        smooth_weight = absmax.pow(alpha) / weight_absmax.pow(1.0 - alpha)
+        smooth_weight = smooth_weight.to(device=device)
+
+        with _maybe_materialize(down_proj_module, device):
+            _inplace_mul_fp32(down_proj_module.weight, smooth_weight.view(1, -1))
+
+        up_device = (
+            up_proj_module.weight.device
+            if not up_proj_module.weight.is_meta
+            else torch.device("cpu")
+        )
+        smooth_weight_up = smooth_weight.to(device=up_device)
+
+        with _maybe_materialize(up_proj_module, up_device):
+            _inplace_div_fp32(up_proj_module.weight, smooth_weight_up.view(-1, 1))
+            if up_proj_module.bias is not None:
+                _inplace_div_fp32(up_proj_module.bias, smooth_weight_up)
+
+        print(
+            f"  [Down] {down_proj_module_name} <-> {up_proj_name}: "
+            f"in_features={absmax.shape[0]}, "
+            f"smooth range=[{smooth_weight.min().item():.4f}, {smooth_weight.max().item():.4f}]"
+        )
+
+    # Execute: serial or parallel
+    sorted_keys = sorted(down_keys)
+
+    if effective_workers <= 1:
+        for stat_key in sorted_keys:
+            _process_one(stat_key)
+    else:
+        with ThreadPoolExecutor(max_workers=effective_workers) as executor:
+            futures = {executor.submit(_process_one, k): k for k in sorted_keys}
+            for fut in as_completed(futures):
+                exc = fut.exception()
+                if exc is not None:
+                    key = futures[fut]
+                    print(f"  [ERROR] {key}: unhandled exception: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# down_proj smooth from alpha search results (pre-computed smooth_weight)
+# ---------------------------------------------------------------------------
+
+def apply_down_proj_smooth_from_search(
+    model: torch.nn.Module,
+    alpha_search_results: dict,
+    num_workers: int = 8,
+    km: dict = None,
+) -> set:
+    """
+    Apply pre-computed smooth_weight from alpha search to down_proj/up_proj.
+
+    Unlike apply_down_proj_smooth(), this function does NOT compute
+    smooth_weight from absmax -- it reads the pre-computed smooth_weight
+    directly from alpha_search_results (output of SmoothAlphaSearcher).
+
+    alpha_search_results format:
+        {
+          "config": {...},
+          "results": {
+            "model.layers.0.mlp.down_proj": {
+              "alpha": [...],
+              "smooth_weight": [float, ...],   # complete [in_features]
+              "loss": float
+            },
+            ...
+          }
+        }
+
+    Application (same as apply_down_proj_smooth):
+        down_proj.weight *= smooth_weight   (dim=1, input channel)
+        up_proj.weight   /= smooth_weight   (dim=0, output channel)
+        up_proj.bias     /= smooth_weight   (if exists)
+
+    Returns:
+        set of stat_keys that were successfully processed.
+    """
+    km = km or DEFAULT_KEY_MAP
+    down_name = km["down_proj"]
+    up_name = km["up_proj"]
+
+    results = alpha_search_results.get("results", alpha_search_results)
+    if not results:
+        print("[Down Smooth Search] No results found in alpha_search_results")
+        return set()
+
+    print(f"\n[Down Smooth Search] {len(results)} entries from alpha search")
+
+    all_named_modules: dict = {name: mod for name, mod in model.named_modules()}
+    up_proj_map: dict = {}
+    for name in all_named_modules:
+        if name.endswith("." + up_name):
+            parent = name[:-(len(up_name) + 1)]
+            up_proj_map[parent] = name
+
+    has_hf_hook = any(
+        getattr(mod, "_hf_hook", None) is not None
+        for mod in all_named_modules.values()
+    )
+    effective_workers = 1 if has_hf_hook else num_workers
+    if has_hf_hook and num_workers > 1:
+        print(f"  [Parallel] accelerate _hf_hook detected -> fallback to serial")
+    else:
+        print(f"  [Parallel] num_workers={effective_workers}")
+
+    def _process_one(stat_key: str, entry: dict) -> str | None:
+        """Process one key. Returns stat_key on success, None on skip."""
+        smooth_weight_list = entry.get("smooth_weight")
+        if smooth_weight_list is None:
+            print(f"  [SKIP] {stat_key}: no smooth_weight in search results")
+            return None
+
+        smooth_weight = torch.tensor(smooth_weight_list, dtype=torch.float32)
+
+        # Validate
+        if torch.any(~torch.isfinite(smooth_weight)):
+            print(f"  [SKIP] {stat_key}: smooth_weight contains inf/nan")
+            return None
+
+        # Locate down_proj module
+        down_proj_module = get_submodule_safe(model, stat_key)
+        if down_proj_module is None:
+            matched_name = None
+            for name in all_named_modules:
+                if name.endswith(stat_key) or stat_key.endswith(name):
+                    matched_name = name
+                    break
+            if matched_name is None:
+                print(f"  [SKIP] {stat_key}: cannot locate down_proj module")
+                return None
+            down_proj_module = get_submodule_safe(model, matched_name)
+            down_proj_module_name = matched_name
+        else:
+            down_proj_module_name = stat_key
+
+        if down_proj_module is None or not hasattr(down_proj_module, "weight"):
+            print(f"  [SKIP] {down_proj_module_name}: no weight attribute")
+            return None
+
+        # Locate matching up_proj
+        parent = down_proj_module_name[:-(len(down_name) + 1)]
+        up_proj_name = up_proj_map.get(parent)
+        if up_proj_name is None:
+            print(f"  [SKIP] {down_proj_module_name}: cannot find matching up_proj")
+            return None
+
+        up_proj_module = get_submodule_safe(model, up_proj_name)
+        if up_proj_module is None or not hasattr(up_proj_module, "weight"):
+            print(f"  [SKIP] {down_proj_module_name}: up_proj {up_proj_name} not usable")
+            return None
+
+        # Apply smooth_weight
+        device = (
+            down_proj_module.weight.device
+            if not down_proj_module.weight.is_meta
+            else torch.device("cpu")
+        )
+        smooth_weight_dev = smooth_weight.to(device=device)
+
+        # down_proj.weight *= smooth_weight  (input channel, dim=1)
+        with _maybe_materialize(down_proj_module, device):
+            _inplace_mul_fp32(down_proj_module.weight, smooth_weight_dev.view(1, -1))
+
+        # up_proj.weight /= smooth_weight  (output channel, dim=0)
+        up_device = (
+            up_proj_module.weight.device
+            if not up_proj_module.weight.is_meta
+            else torch.device("cpu")
+        )
+        smooth_weight_up = smooth_weight.to(device=up_device)
+
+        with _maybe_materialize(up_proj_module, up_device):
+            _inplace_div_fp32(up_proj_module.weight, smooth_weight_up.view(-1, 1))
+            if up_proj_module.bias is not None:
+                _inplace_div_fp32(up_proj_module.bias, smooth_weight_up)
+
+        alpha_info = entry.get("alpha", "?")
+        print(
+            f"  [Down-Search] {down_proj_module_name} <-> {up_proj_name}: "
+            f"in_features={smooth_weight.shape[0]}, "
+            f"smooth range=[{smooth_weight.min().item():.4f}, {smooth_weight.max().item():.4f}], "
+            f"alpha={alpha_info}"
+        )
+        return stat_key
+
+    # Execute and collect successfully processed keys
+    processed_keys = set()
+    sorted_items = sorted(results.items())
+    if effective_workers <= 1:
+        for stat_key, entry in sorted_items:
+            result = _process_one(stat_key, entry)
+            if result is not None:
+                processed_keys.add(result)
+    else:
+        with ThreadPoolExecutor(max_workers=effective_workers) as executor:
+            futures = {
+                executor.submit(_process_one, k, v): k
+                for k, v in sorted_items
+            }
+            for fut in as_completed(futures):
+                exc = fut.exception()
+                if exc is not None:
+                    key = futures[fut]
+                    print(f"  [ERROR] {key}: {exc}")
+                else:
+                    result = fut.result()
+                    if result is not None:
+                        processed_keys.add(result)
+
+    print(f"  [Down-Search] Successfully processed {len(processed_keys)} / {len(results)} entries")
+    return processed_keys
+
+
+# ---------------------------------------------------------------------------
+# MTP / extra weight recovery: load tensors dropped by AutoModelForCausalLM
+# ---------------------------------------------------------------------------
+
+def load_missing_tensors(model_path: str, loaded_keys: set) -> dict:
+    """
+    Load weights that were NOT loaded by AutoModelForCausalLM (e.g. MTP layers).
+
+    Typical case: models with Multi-Token Prediction heads whose extra layers
+    are not registered in the HF architecture and get dropped with
+    "Some weights of the model checkpoint were not used" warning.
+
+    Args:
+        model_path:   original model directory path
+        loaded_keys:  model.state_dict().keys() (keys already loaded by HF)
+
+    Returns:
+        dict[str, torch.Tensor] -- missing key -> CPU tensor mapping;
+        empty dict if nothing is missing.
+    """
+    try:
+        from safetensors import safe_open
+    except ImportError:
+        print("  [WARNING] safetensors not available, cannot supplement missing weights")
+        return {}
+
+    index_path  = os.path.join(model_path, "model.safetensors.index.json")
+    single_path = os.path.join(model_path, "model.safetensors")
+
+    if os.path.exists(index_path):
+        with open(index_path, "r") as f:
+            index = json.load(f)
+        weight_map: dict[str, str] = index["weight_map"]
+    elif os.path.exists(single_path):
+        with safe_open(single_path, framework="pt", device="cpu") as f_st:
+            weight_map = {k: "model.safetensors" for k in f_st.keys()}
+    else:
+        print("  [WARNING] No safetensors index/file found in model_path, skipping")
+        return {}
+
+    missing_keys = set(weight_map.keys()) - loaded_keys
+    if not missing_keys:
+        print("  [MTP] No missing keys, model parameters are complete.")
+        return {}
+
+    print(f"  [MTP] Found {len(missing_keys)} weight keys not loaded by HF (e.g. MTP layers), supplementing:")
+    for k in sorted(missing_keys)[:8]:
+        print(f"    {k}")
+    if len(missing_keys) > 8:
+        print(f"    ... total {len(missing_keys)}")
+
+    # Group by shard file, open each shard only once
+    shard_to_keys: dict[str, list[str]] = {}
+    for k in missing_keys:
+        shard_to_keys.setdefault(weight_map[k], []).append(k)
+
+    missing_tensors: dict[str, torch.Tensor] = {}
+    for shard_file, keys in sorted(shard_to_keys.items()):
+        shard_path = os.path.join(model_path, shard_file)
+        with safe_open(shard_path, framework="pt", device="cpu") as f_st:
+            for k in keys:
+                t = f_st.get_tensor(k)
+                if not t.is_contiguous():
+                    t = t.contiguous()
+                missing_tensors[k] = t
+        print(f"    Loaded {len(keys)} missing keys from {shard_file}")
+
+    return missing_tensors
+
+
+# ---------------------------------------------------------------------------
+# Parallel safetensors save
+# ---------------------------------------------------------------------------
+
+def save_model_parallel(
+    model: torch.nn.Module,
+    save_path: str,
+    shard_size_gb: float = 4.0,
+    num_workers: int = 4,
+    extra_state_dict: dict | None = None,
+) -> None:
+    """
+    Save model weights as safetensors with parallel shard writing.
+
+    Much faster than save_pretrained (which serializes sequentially).
+
+    Flow:
+      1. Collect state_dict, split into shards by shard_size_gb
+      2. ThreadPoolExecutor writes shards concurrently
+      3. Generate model.safetensors.index.json
+      4. Single shard -> write model.safetensors directly (no index)
+
+    Args:
+        model:             transformed model
+        save_path:         output directory (must exist)
+        shard_size_gb:     target size per shard (GiB)
+        num_workers:       concurrent writer threads
+        extra_state_dict:  extra weights to merge (e.g. MTP layers from
+                           load_missing_tensors())
+    """
+    try:
+        from safetensors.torch import save_file as st_save_file
+    except ImportError:
+        raise ImportError(
+            "safetensors is required for parallel saving. "
+            "Install with: pip install safetensors"
+        )
+
+    shard_size_bytes = int(shard_size_gb * 1024 ** 3)
+
+    # 1. Collect state_dict (all contiguous cpu tensors)
+    print(f"  [Save] Collecting state_dict ...")
+    raw_state_dict = model.state_dict()
+    state_dict: dict[str, torch.Tensor] = {}
+    for name, t in raw_state_dict.items():
+        if t.device.type != "cpu":
+            t = t.cpu()
+        if not t.is_contiguous():
+            t = t.contiguous()
+        state_dict[name] = t
+
+    # Merge extra_state_dict (e.g. MTP layers)
+    if extra_state_dict:
+        n_extra = 0
+        for name, t in extra_state_dict.items():
+            if name in state_dict:
+                print(f"  [Save][WARNING] key {name!r} already in state_dict, extra ignored")
+                continue
+            if t.device.type != "cpu":
+                t = t.cpu()
+            if not t.is_contiguous():
+                t = t.contiguous()
+            state_dict[name] = t
+            n_extra += 1
+        print(f"  [Save] Supplemented {n_extra} extra weights (MTP etc.) into state_dict")
+
+    total_bytes = sum(t.nbytes for t in state_dict.values())
+    total_gb    = total_bytes / 1024 ** 3
+    n_shards    = max(1, math.ceil(total_bytes / shard_size_bytes))
+    print(f"  [Save] Total params: {total_gb:.2f} GiB, splitting into {n_shards} shards "
+          f"(each <= {shard_size_gb} GiB)")
+
+    # 2. Assign tensors to shards (greedy, no cross-shard splitting)
+    shard_dicts: list[dict[str, torch.Tensor]] = []
+    cur_shard:   dict[str, torch.Tensor] = {}
+    cur_bytes = 0
+
+    for name, tensor in state_dict.items():
+        nb = tensor.nbytes
+        if cur_bytes + nb > shard_size_bytes and cur_shard:
+            shard_dicts.append(cur_shard)
+            cur_shard = {}
+            cur_bytes = 0
+        cur_shard[name] = tensor
+        cur_bytes += nb
+
+    if cur_shard:
+        shard_dicts.append(cur_shard)
+
+    n_shards = len(shard_dicts)
+
+    # 3. Write shard files concurrently
+    if n_shards == 1:
+        out_file = os.path.join(save_path, "model.safetensors")
+        print(f"  [Save] Single shard -> {out_file}")
+        st_save_file(shard_dicts[0], out_file)
+        print(f"  [Save] Done: {out_file}")
+        return
+
+    pad = len(str(n_shards))
+    shard_filenames = [
+        f"model-{str(i + 1).zfill(pad)}-of-{str(n_shards).zfill(pad)}.safetensors"
+        for i in range(n_shards)
+    ]
+
+    def _write_shard(idx: int) -> tuple[int, str]:
+        fname    = shard_filenames[idx]
+        out_file = os.path.join(save_path, fname)
+        shard_bytes = sum(t.nbytes for t in shard_dicts[idx].values())
+        print(f"  [Save] [{idx+1}/{n_shards}] Writing {fname}  "
+              f"({shard_bytes / 1024**3:.2f} GiB, "
+              f"{len(shard_dicts[idx])} tensors) ...")
+        st_save_file(shard_dicts[idx], out_file)
+        return idx, fname
+
+    effective_workers = min(num_workers, n_shards)
+    print(f"  [Save] Writing {n_shards} shards concurrently, workers={effective_workers}")
+
+    results_list: list[tuple[int, str]] = []
+    with ThreadPoolExecutor(max_workers=effective_workers) as executor:
+        futures = {executor.submit(_write_shard, i): i for i in range(n_shards)}
+        for fut in as_completed(futures):
+            exc = fut.exception()
+            if exc is not None:
+                raise RuntimeError(
+                    f"Shard {futures[fut]} write failed: {exc}"
+                ) from exc
+            results_list.append(fut.result())
+
+    results_list.sort()
+
+    # 4. Generate model.safetensors.index.json
+    weight_map: dict[str, str] = {}
+    for idx, fname in results_list:
+        for key in shard_dicts[idx]:
+            weight_map[key] = fname
+
+    index = {
+        "metadata": {"total_size": str(total_bytes)},
+        "weight_map": weight_map,
+    }
+    index_path = os.path.join(save_path, "model.safetensors.index.json")
+    with open(index_path, "w", encoding="utf-8") as f:
+        json.dump(index, f, indent=2, ensure_ascii=False)
+
+    print(f"  [Save] Index written: {index_path}")
+    print(f"  [Save] All {n_shards} shards written successfully")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    args = parse_args()
+
+    print("=" * 70)
+    print("[Config]")
+    print(f"  model-path:      {args.model_path}")
+    print(f"  smooth-stats:    {args.smooth_stats}")
+    print(f"  save-path:       {args.save_path}")
+    print(f"  alpha-qk:        {args.alpha_qk}")
+    print(f"  alpha-vo:        {args.alpha_vo}")
+    print(f"  use-ema:         {args.use_ema}")
+    print(f"  device:          {args.device}")
+    print(f"  dtype:           {args.dtype}")
+    print(f"  smooth-qk:       {args.smooth_qk}")
+    print(f"  smooth-vo:       {args.smooth_vo}")
+    print(f"  smooth-down:     {args.smooth_down}")
+    print(f"  alpha-down:      {args.alpha_down}")
+    print(f"  down-workers:    {args.down_workers}")
+    print(f"  save-workers:    {args.save_workers}")
+    print(f"  shard-size-gb:   {args.shard_size_gb}")
+    print(f"  patch-mlp-layers:{args.patch_mlp_layers}")
+    print(f"  verify-seq-len:  {args.verify_seq_len}")
+    print(f"  alpha-search:    {args.alpha_search_results or '(none, use fixed alpha)'}")
+    print("=" * 70)
+
+    # Resolve key_map
+    if args.arch == "custom" and args.key_map_file:
+        with open(args.key_map_file, "r") as f:
+            km = json.load(f)
+        print(f"  [KeyMap] Loaded custom key_map from {args.key_map_file}")
+    else:
+        km = PREDEFINED_KEY_MAPS[args.arch]
+        print(f"  [KeyMap] Using predefined key_map: {args.arch}")
+
+    if not args.smooth_qk and not args.smooth_vo and not args.smooth_down:
+        print("\n[WARNING] Neither --smooth-qk, --smooth-vo, nor --smooth-down is set. "
+              "No weight transformation will be applied. "
+              "Use --smooth-qk / --smooth-vo / --smooth-down to enable conversion.")
+        return
+
+    # ------------------------------------------------------------------
+    # Step 1: Load model
+    # ------------------------------------------------------------------
+    print(f"\n[Step 1] Loading model from {args.model_path} ...")
+
+    dtype_map = {
+        "float32":  torch.float32,
+        "float16":  torch.float16,
+        "bfloat16": torch.bfloat16,
+        "auto":     "auto",
+    }
+    torch_dtype = dtype_map.get(args.dtype, "auto")
+
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model_path,
+        torch_dtype=torch_dtype,
+        device_map=args.device,
+        trust_remote_code=True,
+        low_cpu_mem_usage=True,
+    )
+    model.eval()
+    print(f"  Model loaded: {type(model).__name__}")
+
+    # Load tokenizer (optional, for saving alongside model)
+    tokenizer = None
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(
+            args.model_path, trust_remote_code=True
+        )
+        print(f"  Tokenizer loaded: {type(tokenizer).__name__}")
+    except Exception as e:
+        print(f"  [WARNING] Could not load tokenizer: {e}")
+
+    # Infer head_dim from model config
+    cfg      = model.config
+    head_dim = getattr(cfg, "head_dim", None)
+    if head_dim is None:
+        num_heads   = getattr(cfg, "num_attention_heads", None)
+        hidden_size = getattr(cfg, "hidden_size", None)
+        if num_heads and hidden_size:
+            head_dim = hidden_size // num_heads
+    print(f"  head_dim inferred: {head_dim}")
+
+    # ------------------------------------------------------------------
+    # Step 2: Load smooth stats
+    # ------------------------------------------------------------------
+    print(f"\n[Step 2] Loading smooth stats from {args.smooth_stats} ...")
+    smooth_stats = load_smooth_stats(args.smooth_stats, use_ema=args.use_ema)
+    print(f"  Loaded {len(smooth_stats)} stat entries")
+    sample_keys = list(smooth_stats.keys())[:6]
+    for k in sample_keys:
+        sc = smooth_stats[k]["scale"]
+        print(f"    {k!r:70s}  shape={list(sc.shape) if sc is not None else None}")
+    if len(smooth_stats) > 6:
+        print(f"    ... and {len(smooth_stats) - 6} more")
+
+    # ------------------------------------------------------------------
+    # Step 2.5: Record pre-transform attn output (for verification)
+    # ------------------------------------------------------------------
+    verify_snap = snapshot_attn_output_before(model, smooth_stats, seq_len=args.verify_seq_len, seed=42, km=km)
+
+    # ------------------------------------------------------------------
+    # Step 2.6: Record pre-transform MLP module output (for verification)
+    # ------------------------------------------------------------------
+    mlp_snap = snapshot_mlp_outputs_before(
+        model,
+        patch_n=args.patch_mlp_layers,
+        seq_len=args.verify_seq_len,
+        seed=42,
+        km=km,
+    )
+
+    # ------------------------------------------------------------------
+    # Step 3: Apply smooth transforms
+    # ------------------------------------------------------------------
+    print(f"\n[Step 3] Applying offline smooth transforms ...")
+
+    # QK smooth
+    if args.smooth_qk:
+        has_qk = any(k.endswith(km["stat_k"]) for k in smooth_stats) and \
+                 any(k.endswith(km["stat_q"]) for k in smooth_stats)
+        if has_qk:
+            apply_qk_smooth(model, smooth_stats, alpha=args.alpha_qk, head_dim=head_dim, km=km)
+        else:
+            print("  [SKIP] QK smooth: no attn.k / attn.q stats found in smooth-stats")
+    else:
+        print("  [SKIP] QK smooth: --smooth-qk not set")
+
+    # VO smooth
+    if args.smooth_vo:
+        has_vo = any(k.endswith(km["stat_attn_out"]) for k in smooth_stats)
+        if has_vo:
+            apply_vo_smooth(model, smooth_stats, alpha=args.alpha_vo, head_dim=head_dim, km=km)
+        else:
+            print("  [SKIP] VO smooth: no attn_out stats found in smooth-stats")
+    else:
+        print("  [SKIP] VO smooth: --smooth-vo not set")
+
+    # Down proj smooth (two-step: alpha search first, then fixed alpha fallback)
+    if args.smooth_down:
+        search_processed_keys = set()
+
+        # Step 1: If alpha search results provided, apply them first
+        if args.alpha_search_results:
+            print(f"\n[Down Smooth] Using alpha search results: {args.alpha_search_results}")
+            with open(args.alpha_search_results, "r") as f:
+                alpha_search = json.load(f)
+            search_processed_keys = apply_down_proj_smooth_from_search(
+                model, alpha_search, num_workers=args.down_workers, km=km
+            )
+
+        # Step 2: Fallback -- for keys NOT in alpha search, use fixed alpha
+        import re as _re
+        _DOWN_PATTERNS = [_re.compile(p) for p in km["down_patterns"]]
+        has_down = any(
+            any(pat.search(k) for pat in _DOWN_PATTERNS)
+            for k in smooth_stats
+        )
+        if has_down:
+            apply_down_proj_smooth(
+                model, smooth_stats, alpha=args.alpha_down,
+                num_workers=args.down_workers,
+                exclude_keys=search_processed_keys,
+                km=km,
+            )
+        elif not search_processed_keys:
+            print("  [SKIP] Down smooth: no down_proj stats found in smooth-stats")
+    else:
+        print("  [SKIP] Down smooth: --smooth-down not set")
+
+    # ------------------------------------------------------------------
+    # Step 3.5: Verify attn output diff
+    # ------------------------------------------------------------------
+    verify_attn_output_diff(verify_snap, model, atol=1e-3, rtol=1e-3, km=km)
+
+    # ------------------------------------------------------------------
+    # Step 3.6: Verify MLP output diff
+    # ------------------------------------------------------------------
+    verify_mlp_output_diff(mlp_snap, atol=1e-2, rtol=1e-2)
+
+    # ------------------------------------------------------------------
+    # Step 4: Save transformed model
+    # ------------------------------------------------------------------
+    print(f"\n[Step 4] Saving transformed model to {args.save_path} ...")
+    os.makedirs(args.save_path, exist_ok=True)
+
+    # Supplement MTP / extra weights dropped by AutoModelForCausalLM
+    print(f"\n[Step 4.1] Detecting and supplementing extra weights (MTP etc.)...")
+    loaded_keys = set(model.state_dict().keys())
+    extra_state_dict = load_missing_tensors(args.model_path, loaded_keys)
+
+    # Parallel safetensors shard writing
+    save_model_parallel(
+        model,
+        args.save_path,
+        shard_size_gb=args.shard_size_gb,
+        num_workers=args.save_workers,
+        extra_state_dict=extra_state_dict if extra_state_dict else None,
+    )
+
+    # Copy config / tokenizer / non-weight files from original model directory
+    _NON_WEIGHT_EXTS = {".json", ".txt", ".py", ".model", ".tiktoken"}
+    _SKIP_FILES = {"model.safetensors.index.json"}
+    copied = []
+    for fname in os.listdir(args.model_path):
+        if fname in _SKIP_FILES:
+            continue
+        if fname.startswith("model-") and fname.endswith(".safetensors"):
+            continue
+        if fname == "model.safetensors":
+            continue
+        ext = os.path.splitext(fname)[1].lower()
+        if ext in _NON_WEIGHT_EXTS:
+            src = os.path.join(args.model_path, fname)
+            dst = os.path.join(args.save_path, fname)
+            if not os.path.exists(dst):
+                shutil.copy2(src, dst)
+                copied.append(fname)
+    if copied:
+        print(f"  [Save] Copied config files: {copied}")
+
+    if tokenizer is not None:
+        tokenizer.save_pretrained(args.save_path)
+    print(f"  Done. Saved to {args.save_path}")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/smooth/run_vllm_smooth.py
+++ b/tools/smooth/run_vllm_smooth.py
@@ -1,0 +1,649 @@
+# Copyright 2025 Tencent Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Offline SmoothQuant scale calibration tool.
+
+Collects per-channel absmax / EMA statistics for:
+  - Attention layers (q, k inputs and attn output = o_proj input)
+  - Dense MLP down_proj input  (= silu(gate) * up)
+  - FusedMoE down_proj input   (requires VLLM_MOE_COLLECT_SMOOTH_STATS=1
+                                 and vLLM kernel source modification)
+
+Control which statistics to collect via --collect-attn / --collect-down-proj /
+--collect-moe flags (all enabled by default).
+"""
+
+import argparse
+import json
+import os
+import platform
+
+from vllm import LLM, SamplingParams
+
+from angelslim.compressor.quant import (
+    get_smooth_stats,
+    print_smooth_stats,
+    setup_smooth_hooks,
+    SmoothAlphaSearchConfig,
+    SmoothAlphaSearcher,
+    setup_smooth_alpha_search_hooks,
+    remove_smooth_alpha_search_hooks,
+)
+from angelslim.engine import Engine
+
+_original_python_version = platform.python_version
+
+
+def _patched_python_version():
+    return _original_python_version().rstrip("+")
+
+
+platform.python_version = _patched_python_version
+
+
+# ---------------------------------------------------------------------------
+# Helper functions to access draft (MTP) model via collective_rpc
+# ---------------------------------------------------------------------------
+
+def _get_draft_model_from_worker(worker):
+    """
+    Extract the draft (MTP) model from a vLLM worker instance.
+    Works by traversing: worker -> model_runner -> drafter -> model.
+
+    This function is designed to be called inside collective_rpc, where the
+    worker argument is a WorkerWrapperBase (mp executor) or WorkerBase subclass.
+    """
+    model_runner = getattr(worker, "model_runner", None)
+    if model_runner is None:
+        return None
+    drafter = getattr(model_runner, "drafter", None)
+    if drafter is None:
+        return None
+    return getattr(drafter, "model", None)
+
+
+def _apply_on_draft_model(worker, fn):
+    """
+    Apply a function on the draft model inside a worker.
+    This is a collective_rpc-compatible callable: collective_rpc passes
+    the worker as the first argument when method is a callable.
+
+    Usage:
+        llm.llm_engine.collective_rpc(
+            lambda w: _apply_on_draft_model(w, some_fn)
+        )
+    """
+    draft_model = _get_draft_model_from_worker(worker)
+    if draft_model is not None:
+        return fn(draft_model)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="vLLM SmoothQuant Calibration Tool — collect per-channel absmax/EMA statistics"
+    )
+
+    # Model configuration
+    parser.add_argument(
+        "--model-path", type=str, help="Path to the model directory"
+    )
+    parser.add_argument(
+        "--ptq-data-path",
+        type=str,
+        help="Path to the PTQ calibration data (JSONL format)",
+    )
+    parser.add_argument(
+        "--output-dir", type=str, help="Directory to save output JSON"
+    )
+
+    # Model loading
+    parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size (default: 1)")
+    parser.add_argument(
+        "--skip-weight-loading",
+        action="store_true",
+        help="Use dummy weights for fast debug (outputs will be random)",
+    )
+
+    # Dataset
+    parser.add_argument(
+        "--batch-size", type=int, default=128, help="Batch size for inference (default: 128)"
+    )
+    parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=512,
+        help="Number of calibration samples (default: 512)",
+    )
+    parser.add_argument(
+        "--max-length",
+        type=int,
+        default=16384,
+        help="Maximum sequence length (default: 16384)",
+    )
+
+    # Distributed
+    parser.add_argument(
+        "--distributed-executor-backend",
+        type=str,
+        default="ray",
+        choices=["ray", "mp"],
+        help="Distributed executor backend (default: ray)",
+    )
+
+    # MTP (Multi-Token Prediction) configuration
+    parser.add_argument(
+        "--enable-mtp",
+        action="store_true",
+        help="Enable MTP (Multi-Token Prediction) speculative decoding and register "
+             "smooth hooks on the MTP draft model",
+    )
+    parser.add_argument(
+        "--num-speculative-tokens",
+        type=int,
+        default=1,
+        help="Number of speculative tokens for MTP (default: 1, only used when --enable-mtp is set)",
+    )
+
+    # EMA
+    parser.add_argument(
+        "--ema-momentum",
+        type=float,
+        default=0.9,
+        help="EMA momentum for smooth stats (default: 0.9)",
+    )
+
+    # --- Scope control ---
+    parser.add_argument(
+        "--collect-attn",
+        action="store_true",
+        default=None,
+        help="Collect attention q/k/attn_out smooth stats (default: on unless any --collect-* flag is given)",
+    )
+    parser.add_argument(
+        "--collect-down-proj",
+        action="store_true",
+        default=None,
+        help="Collect dense MLP down_proj input smooth stats",
+    )
+    parser.add_argument(
+        "--collect-moe",
+        action="store_true",
+        default=None,
+        help=(
+            "Collect FusedMoE down_proj input smooth stats. "
+            "Requires VLLM_MOE_COLLECT_SMOOTH_STATS=1 and vLLM kernel modification."
+        ),
+    )
+
+    # Output
+    parser.add_argument(
+        "--output-filename",
+        type=str,
+        default="smooth_stats.json",
+        help="Output JSON filename (default: smooth_stats.json)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print detailed statistics after collection",
+    )
+    parser.add_argument(
+        "--print-max-rows",
+        type=int,
+        default=40,
+        help="Max rows to print in summary table (default: 40)",
+    )
+
+    # --- Alpha Grid Search ---
+    parser.add_argument(
+        "--enable-alpha-search",
+        action="store_true",
+        help="Enable per-layer alpha grid search for optimal SmoothQuant alpha (down_proj only)",
+    )
+    parser.add_argument(
+        "--num-search-samples",
+        type=int,
+        default=16,
+        help="Number of samples for alpha search (separate from smooth stat samples, default: 16)",
+    )
+    parser.add_argument(
+        "--search-max-length",
+        type=int,
+        default=None,
+        help="Max token length for alpha search data (default: same as --max-length). "
+             "Set lower (e.g. 8192) to speed up search inference.",
+    )
+    parser.add_argument("--alpha-min", type=float, default=0.3, help="Min alpha for grid search (default: 0.3)")
+    parser.add_argument("--alpha-max", type=float, default=1.0, help="Max alpha for grid search (default: 1.0)")
+    parser.add_argument("--alpha-steps", type=int, default=8, help="Number of grid search points (default: 8)")
+    parser.add_argument(
+        "--alpha-act-quant-method", type=str, default="per_token",
+        choices=["per_tensor", "per_token"],
+        help="Activation quantization granularity for alpha search (default: per_token)",
+    )
+    parser.add_argument(
+        "--alpha-act-quant-type", type=str, default="int8",
+        choices=["int8", "fp8"],
+        help="Activation quantization dtype for alpha search (default: int8)",
+    )
+    parser.add_argument(
+        "--alpha-weight-quant-method", type=str, default="per_channel",
+        choices=["per_tensor", "per_channel", "per_group", "per_block"],
+        help="Weight quantization granularity for alpha search (default: per_channel)",
+    )
+    parser.add_argument(
+        "--alpha-weight-quant-type", type=str, default="int8",
+        choices=["int8", "int4", "fp8"],
+        help="Weight quantization dtype for alpha search (default: int8)",
+    )
+    parser.add_argument("--alpha-weight-quant-bits", type=int, default=8, help="Weight quant bit width (default: 8)")
+    parser.add_argument("--alpha-weight-group-size", type=int, default=128, help="Group size for per_group weight quant (default: 128)")
+    parser.add_argument("--alpha-max-tokens", type=int, default=4096, help="Max tokens per layer for alpha search (default: 4096)")
+    parser.add_argument("--alpha-use-ema", action="store_true", help="Use EMA instead of absmax for smooth formula in alpha search")
+    parser.add_argument(
+        "--alpha-smooth-search-mode", type=str, default="default",
+        choices=["default", "per-tensor-act-first"],
+        help="Alpha search strategy: 'default' (act^a/weight^(1-a)) or "
+             "'per-tensor-act-first' (scale all channels to unified target absmax) (default: default)",
+    )
+    parser.add_argument("--alpha-act-mul-min", type=float, default=0.1,
+                        help="per-tensor-act-first mode: min multiplier for target absmax (default: 0.1)")
+    parser.add_argument("--alpha-act-mul-max", type=float, default=1.0,
+                        help="per-tensor-act-first mode: max multiplier for target absmax (default: 1.0)")
+    parser.add_argument("--alpha-smooth-min", type=float, default=1e-6,
+                        help="per-tensor-act-first mode: smooth weight clamp lower bound (default: 1e-6)")
+    parser.add_argument("--alpha-smooth-max", type=float, default=1e6,
+                        help="per-tensor-act-first mode: smooth weight clamp upper bound (default: 1e6)")
+
+    # YAML config support
+    parser.add_argument("-c", "--config", type=str, default=None,
+                        help="YAML config file path. Values override argparse defaults; "
+                             "explicit CLI flags still take final precedence.")
+
+    args = parser.parse_args()
+    # Lazy-import _yaml_args (located in tools/). Done here instead of at
+    # module top so flake8 doesn't trip on a sys.path mutation between
+    # imports.
+    import sys
+    _tools_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if _tools_dir not in sys.path:
+        sys.path.insert(0, _tools_dir)
+    from _yaml_args import apply_yaml_config
+    apply_yaml_config(parser, args)
+
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Scope-filtered setup / get helpers
+# ---------------------------------------------------------------------------
+
+class _ScopedSmoothHooks:
+    """
+    Pickle-safe callable that passes scope flags directly to setup_smooth_hooks.
+    Required because llm.apply_model serialises the function via ray/mp.
+    """
+
+    def __init__(self, collect_attn, collect_down_proj, collect_moe, ema_momentum):
+        self.collect_attn = collect_attn
+        self.collect_down_proj = collect_down_proj
+        self.collect_moe = collect_moe
+        self.ema_momentum = ema_momentum
+
+    def __call__(self, model):
+        return setup_smooth_hooks(
+            model,
+            ema_momentum=self.ema_momentum,
+            collect_attn=self.collect_attn,
+            collect_down_proj=self.collect_down_proj,
+            collect_moe=self.collect_moe,
+        )
+
+
+class _ScopedAlphaSearchHooks:
+    """Pickle-safe callable for setup_smooth_alpha_search_hooks."""
+
+    def __init__(self, max_tokens, collect_moe):
+        self.max_tokens = max_tokens
+        self.collect_moe = collect_moe
+
+    def __call__(self, model):
+        return setup_smooth_alpha_search_hooks(
+            model,
+            max_tokens=self.max_tokens,
+            collect_moe=self.collect_moe,
+        )
+
+
+def _resolve_scopes(args):
+    """
+    If none of the --collect-* flags are given, enable all three scopes.
+    If at least one is given, only enable the explicitly requested ones.
+    """
+    any_explicit = any([args.collect_attn, args.collect_down_proj, args.collect_moe])
+    collect_attn      = bool(args.collect_attn)      if any_explicit else True
+    collect_down_proj = bool(args.collect_down_proj) if any_explicit else True
+    collect_moe       = bool(args.collect_moe)       if any_explicit else True
+    return collect_attn, collect_down_proj, collect_moe
+
+
+# ---------------------------------------------------------------------------
+# Save helper
+# ---------------------------------------------------------------------------
+
+def save_stats_to_json(stats_data, output_dir, filename, stats_type="statistics"):
+    if isinstance(stats_data, list):
+        if not stats_data or stats_data[0] is None:
+            print(f"\nNo {stats_type} available.")
+            return
+        stats_data = stats_data[0]
+
+    if stats_data is None:
+        print(f"\nNo {stats_type} available.")
+        return
+
+    os.makedirs(output_dir, exist_ok=True)
+    output_file = os.path.join(output_dir, filename)
+    with open(output_file, "w") as f:
+        json.dump(stats_data, f, indent=2)
+    print(f"\n{stats_type.capitalize()} saved to: {output_file}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    args = parse_args()
+    collect_attn, collect_down_proj, collect_moe = _resolve_scopes(args)
+
+    # ------------------------------------------------------------------
+    # Print configuration
+    # ------------------------------------------------------------------
+    print("\nConfiguration:")
+    print(f"  Model:            {args.model_path}")
+    print(f"  PTQ Data:         {args.ptq_data_path}")
+    print(f"  Output Dir:       {args.output_dir}")
+    print(f"  TP Size:          {args.tp_size}")
+    print(f"  Batch Size:       {args.batch_size}")
+    print(f"  Num Samples:      {args.num_samples}")
+    print(f"  EMA Momentum:     {args.ema_momentum}")
+    print(f"  Skip Weight Load: {args.skip_weight_loading}")
+    print(f"\nCollection scope:")
+    print(f"  Attention (q/k/attn_out): {'ON' if collect_attn else 'OFF'}")
+    print(f"  Dense down_proj input:    {'ON' if collect_down_proj else 'OFF'}")
+    print(f"  FusedMoE down_proj input: {'ON' if collect_moe else 'OFF'}")
+    if collect_moe:
+        moe_env = os.environ["VLLM_MOE_COLLECT_SMOOTH_STATS"]="1"
+        print(f"  VLLM_MOE_COLLECT_SMOOTH_STATS={moe_env}")
+        if moe_env != "1":
+            print(
+                "  [WARNING] VLLM_MOE_COLLECT_SMOOTH_STATS is not set to 1. "
+                "MoE smooth stats will NOT be collected."
+            )
+
+    # Configure MTP speculative decoding
+    speculative_config = None
+    if args.enable_mtp:
+        speculative_config = {
+            "method": "hunyuan_mtp",
+            "num_speculative_tokens": args.num_speculative_tokens,
+        }
+        print(f"  MTP Enabled:      True (num_speculative_tokens={args.num_speculative_tokens})")
+    else:
+        print(f"  MTP Enabled:      False")
+
+    if args.enable_alpha_search:
+        print(f"\nAlpha Grid Search:")
+        print(f"  Num Search Samples: {args.num_search_samples}")
+        print(f"  Search Max Length:  {args.search_max_length or args.max_length}")
+        print(f"  Alpha Range:        [{args.alpha_min}, {args.alpha_max}], steps={args.alpha_steps}")
+        print(f"  Act Quant:          {args.alpha_act_quant_method} / {args.alpha_act_quant_type}")
+        print(f"  Weight Quant:       {args.alpha_weight_quant_method} / {args.alpha_weight_quant_type} / {args.alpha_weight_quant_bits}bit")
+        print(f"  Max Tokens/Layer:   {args.alpha_max_tokens}")
+        print(f"  Use EMA:            {args.alpha_use_ema}")
+
+    # ------------------------------------------------------------------
+    # Create LLM instance
+    # ------------------------------------------------------------------
+    llm = LLM(
+        model=args.model_path,
+        load_format="dummy" if args.skip_weight_loading else "auto",
+        disable_log_stats=False,
+        enforce_eager=True,
+        enable_chunked_prefill=True,
+        max_num_batched_tokens=16384,
+        gpu_memory_utilization=0.75,
+        tensor_parallel_size=args.tp_size,
+        distributed_executor_backend=args.distributed_executor_backend,
+        enable_expert_parallel=False,
+        max_num_seqs=args.batch_size,
+        max_model_len=args.max_length + 16,
+        speculative_config=speculative_config,
+        # Force TRITON MoE backend so that the AngelSlim collection hooks
+        # injected in TritonExperts.apply() (fused_moe.py) are actually reached.
+        # Default "auto" may select FlashInfer/CUTLASS backends which bypass
+        # the injected code entirely.
+        moe_backend="triton",
+    )
+
+    if args.skip_weight_loading:
+        print("\n" + "!" * 80)
+        print("WARNING: Running with dummy weights (random values)!")
+        print("Outputs will NOT make sense. This is for debugging only.")
+        print("!" * 80 + "\n")
+
+    # ------------------------------------------------------------------
+    # Setup smooth hooks (main model)
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 80)
+    print("Setting up smooth hooks...")
+    print("=" * 80)
+    setup_fn = _ScopedSmoothHooks(
+        collect_attn=collect_attn,
+        collect_down_proj=collect_down_proj,
+        collect_moe=collect_moe,
+        ema_momentum=args.ema_momentum,
+    )
+    hook_results = llm.apply_model(setup_fn)
+    for i, result in enumerate(hook_results):
+        print(f"Worker {i}: {result}")
+
+    # ------------------------------------------------------------------
+    # Setup smooth hooks (MTP draft model, if --enable-mtp is set)
+    # ------------------------------------------------------------------
+    if args.enable_mtp:
+        print("\n" + "=" * 80)
+        print("Setting up MTP draft model smooth hooks...")
+        print("=" * 80)
+        mtp_hook_results = llm.llm_engine.collective_rpc(
+            lambda w: _apply_on_draft_model(w, setup_fn)
+        )
+        for i, result in enumerate(mtp_hook_results):
+            if result is not None:
+                print(f"Worker {i}: {result}")
+            else:
+                print(f"Worker {i}: No MTP draft model available")
+
+    # ------------------------------------------------------------------
+    # Load dataset and prepare prompts (split into smooth + search groups)
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 80)
+    print("Loading dataset and preparing prompts...")
+    print("=" * 80)
+    tokenizer = llm.get_tokenizer()
+
+    num_search = args.num_search_samples if args.enable_alpha_search else 0
+    total_samples = args.num_samples + num_search
+
+    slim_engine = Engine()
+    slim_engine.slim_model = llm
+    slim_engine.series = "LLM"
+    slim_engine.slim_model.tokenizer = tokenizer
+    slim_engine.slim_model.model = llm
+    slim_engine.slim_model.model.device = "cpu"
+    dataset = slim_engine.prepare_data(
+        data_path=args.ptq_data_path,
+        max_length=args.max_length,
+        num_samples=total_samples,
+        shuffle=False,
+        inference_settings=None,
+        use_audio_in_video=False,
+    )
+
+    # Materialise DataLoader into a list so we can slice it
+    all_data = list(dataset)
+    print(f"Total dataset samples loaded: {len(all_data)}")
+
+    # Split: first num_samples for smooth stat, next num_search for alpha search
+    smooth_dataset = all_data[:args.num_samples]
+    smooth_prompts = [tokenizer.decode(data["input_ids"][0]) for data in smooth_dataset]
+    print(f"Smooth prompts: {len(smooth_prompts)}")
+
+    search_prompts = []
+    if args.enable_alpha_search and num_search > 0:
+        search_dataset = all_data[args.num_samples : args.num_samples + num_search]
+        search_max_len = args.search_max_length or args.max_length
+        for data in search_dataset:
+            ids = data["input_ids"][0]
+            if search_max_len < args.max_length:
+                ids = ids[:search_max_len]
+            search_prompts.append(tokenizer.decode(ids))
+        print(f"Search prompts: {len(search_prompts)} (max_length={search_max_len})")
+
+    # ------------------------------------------------------------------
+    # Phase B: Forward pass — collect smooth stats (prefill only)
+    # ------------------------------------------------------------------
+    sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=1)
+
+    print("\n" + "=" * 80)
+    print(f"[Phase B] Running smooth stat calibration ({len(smooth_prompts)} samples)...")
+    print("=" * 80)
+    outputs = llm.generate(smooth_prompts, sampling_params)
+    print(f"Smooth stat sequences processed: {len(outputs)}")
+
+    # ------------------------------------------------------------------
+    # Phase C+D: Alpha grid search (if enabled)
+    # ------------------------------------------------------------------
+    if args.enable_alpha_search and search_prompts:
+        print("\n" + "=" * 80)
+        print(f"[Phase C] Setting up alpha search hooks + running search inference ({len(search_prompts)} samples)...")
+        print("=" * 80)
+
+        alpha_setup_fn = _ScopedAlphaSearchHooks(
+            max_tokens=args.alpha_max_tokens,
+            collect_moe=collect_moe,
+        )
+        alpha_hook_results = llm.apply_model(alpha_setup_fn)
+        for i, result in enumerate(alpha_hook_results):
+            print(f"  Worker {i}: {result}")
+
+
+        # ------ Phase C generate ------
+        search_outputs = llm.generate(search_prompts, sampling_params)
+        print(f"  Search sequences processed: {len(search_outputs)}")
+
+        print("\n" + "=" * 80)
+        print("[Phase D] Running alpha grid search...")
+        print("=" * 80)
+
+        # ------ Phase D search ------
+        alpha_config = SmoothAlphaSearchConfig(
+            alpha_min=args.alpha_min,
+            alpha_max=args.alpha_max,
+            alpha_steps=args.alpha_steps,
+            act_quant_method=args.alpha_act_quant_method,
+            act_quant_type=args.alpha_act_quant_type,
+            weight_quant_method=args.alpha_weight_quant_method,
+            weight_quant_type=args.alpha_weight_quant_type,
+            weight_quant_bits=args.alpha_weight_quant_bits,
+            weight_group_size=args.alpha_weight_group_size,
+            max_tokens_per_layer=args.alpha_max_tokens,
+            use_ema_for_absmax=args.alpha_use_ema,
+            smooth_search_mode=args.alpha_smooth_search_mode,
+            act_mul_min=args.alpha_act_mul_min,
+            act_mul_max=args.alpha_act_mul_max,
+            smooth_min=args.alpha_smooth_min,
+            smooth_max=args.alpha_smooth_max,
+        )
+        alpha_output_path = os.path.join(args.output_dir, "smooth_alpha_search.json")
+        searcher = SmoothAlphaSearcher(alpha_config, output_path=alpha_output_path)
+        alpha_results_list = llm.apply_model(searcher)
+        for i, summary in enumerate(alpha_results_list):
+            print(f"  Worker {i}: {summary}")
+        print(f"\nAlpha search results saved to: {alpha_output_path}")
+
+        # Cleanup alpha search hooks
+        llm.apply_model(remove_smooth_alpha_search_hooks)
+
+    # ------------------------------------------------------------------
+    # Phase E: Collect and save smooth statistics (all_gather, slow)
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 80)
+    print("[Phase E] Collecting smooth statistics (all_gather)...")
+    print("=" * 80)
+
+    if args.verbose:
+        llm.apply_model(lambda model: print_smooth_stats(model, max_rows=args.print_max_rows))
+
+    if args.enable_mtp and args.verbose:
+        print("\n[MTP] Draft Model Smooth Statistics:")
+        llm.llm_engine.collective_rpc(
+            lambda w: _apply_on_draft_model(
+                w, lambda m: print_smooth_stats(m, max_rows=args.print_max_rows)
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Save statistics (main model)
+    # ------------------------------------------------------------------
+    smooth_stats_list = llm.apply_model(get_smooth_stats)
+    save_stats_to_json(
+        smooth_stats_list,
+        args.output_dir,
+        args.output_filename,
+        stats_type="smooth statistics",
+    )
+
+    # ------------------------------------------------------------------
+    # Save statistics (MTP draft model, if --enable-mtp is set)
+    # ------------------------------------------------------------------
+    if args.enable_mtp:
+        mtp_smooth_stats_list = llm.llm_engine.collective_rpc(
+            lambda w: _apply_on_draft_model(w, get_smooth_stats)
+        )
+        # Derive MTP output filename: e.g. smooth_stats.json -> mtp_smooth_stats.json
+        base, ext = os.path.splitext(args.output_filename)
+        mtp_output_filename = f"mtp_{base}{ext}"
+        save_stats_to_json(
+            mtp_smooth_stats_list,
+            args.output_dir,
+            mtp_output_filename,
+            stats_type="MTP smooth statistics",
+        )
+
+    print("\n" + "=" * 80)
+    print("Smooth stat calibration completed successfully!")
+    print(f"Results saved to: {args.output_dir}")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/vllm_patch/envs.py
+++ b/tools/vllm_patch/envs.py
@@ -1641,6 +1641,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_MOE_COLLECT_PER_EXPERT_STATS": lambda: bool(
         int(os.getenv("VLLM_MOE_COLLECT_PER_EXPERT_STATS", "0"))
     ),
+    # Enable MoE smooth stats collection (per-channel absmax/EMA).
+    "VLLM_MOE_COLLECT_SMOOTH_STATS": lambda: bool(
+        int(os.getenv("VLLM_MOE_COLLECT_SMOOTH_STATS", "0"))
+    ),
+    # Enable MoE alpha search raw activation collection.
+    "VLLM_MOE_COLLECT_ALPHA_SEARCH": lambda: bool(
+        int(os.getenv("VLLM_MOE_COLLECT_ALPHA_SEARCH", "0"))
+    ),
     # === /AngelSlim ===
 }
 

--- a/tools/vllm_patch/fused_moe.py
+++ b/tools/vllm_patch/fused_moe.py
@@ -52,6 +52,24 @@ except ImportError as _e:
         pass
 
 
+# Import smooth stats and alpha search collection functions.
+try:
+    from vllm_calibrate_utils import collect_fused_moe_smooth_stats  # noqa: E402
+    _angelslim_logger.info("[AngelSlim] Successfully imported collect_fused_moe_smooth_stats")
+except ImportError:
+    def collect_fused_moe_smooth_stats(*args, **kwargs):
+        """No-op fallback."""
+        pass
+
+try:
+    from vllm_calibrate_utils import collect_fused_moe_alpha_search_values  # noqa: E402
+    _angelslim_logger.info("[AngelSlim] Successfully imported collect_fused_moe_alpha_search_values")
+except ImportError:
+    def collect_fused_moe_alpha_search_values(*args, **kwargs):
+        """No-op fallback."""
+        pass
+
+
 # === /AngelSlim ===
 from vllm.model_executor.layers.fused_moe.activation import (
     MoEActivation,
@@ -2163,6 +2181,24 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
             global_num_experts=global_num_experts,
             layer_name=_layer_name,
             global_moe_activation_stats=_moe_activation_stats,
+        )
+        # Smooth stats collection (per-channel absmax/EMA for SmoothQuant).
+        collect_fused_moe_smooth_stats(
+            stage="down_proj",
+            hidden_states=intermediate_cache2,
+            topk_ids=topk_ids,
+            layer_name=getattr(w1, '_vllm_layer_name_smooth', None),
+            global_smooth_stats=getattr(w1, '_smooth_stats_of_model', None),
+            ema_momentum=getattr(w1, '_smooth_ema_momentum', 0.9),
+        )
+        # Alpha search raw activation collection.
+        collect_fused_moe_alpha_search_values(
+            stage="down_proj",
+            hidden_states=intermediate_cache2,
+            topk_ids=topk_ids,
+            layer_name=getattr(w1, '_vllm_layer_name_smooth', None),
+            alpha_search_values=getattr(w1, '_alpha_search_values_of_model', None),
+            max_tokens_per_expert=getattr(w1, '_alpha_search_max_tokens', 512),
         )
         # === /AngelSlim ===
 

--- a/tools/vllm_patch/install.sh
+++ b/tools/vllm_patch/install.sh
@@ -163,10 +163,38 @@ do_check() {
         ok=0
     fi
 
+    if grep -q "VLLM_MOE_COLLECT_SMOOTH_STATS" "${envs_dst}" 2>/dev/null; then
+        log "  [OK]   envs.py contains VLLM_MOE_COLLECT_SMOOTH_STATS"
+    else
+        err  "  [FAIL] envs.py does NOT contain VLLM_MOE_COLLECT_SMOOTH_STATS"
+        ok=0
+    fi
+
+    if grep -q "VLLM_MOE_COLLECT_ALPHA_SEARCH" "${envs_dst}" 2>/dev/null; then
+        log "  [OK]   envs.py contains VLLM_MOE_COLLECT_ALPHA_SEARCH"
+    else
+        err  "  [FAIL] envs.py does NOT contain VLLM_MOE_COLLECT_ALPHA_SEARCH"
+        ok=0
+    fi
+
     if grep -q "collect_fused_moe_internal_stats" "${fused_moe_dst}" 2>/dev/null; then
         log "  [OK]   fused_moe.py contains collect_fused_moe_internal_stats"
     else
         err  "  [FAIL] fused_moe.py does NOT contain collect_fused_moe_internal_stats"
+        ok=0
+    fi
+
+    if grep -q "collect_fused_moe_smooth_stats" "${fused_moe_dst}" 2>/dev/null; then
+        log "  [OK]   fused_moe.py contains collect_fused_moe_smooth_stats"
+    else
+        err  "  [FAIL] fused_moe.py does NOT contain collect_fused_moe_smooth_stats"
+        ok=0
+    fi
+
+    if grep -q "collect_fused_moe_alpha_search_values" "${fused_moe_dst}" 2>/dev/null; then
+        log "  [OK]   fused_moe.py contains collect_fused_moe_alpha_search_values"
+    else
+        err  "  [FAIL] fused_moe.py does NOT contain collect_fused_moe_alpha_search_values"
         ok=0
     fi
 


### PR DESCRIPTION
Introduces an end-to-end SmoothQuant flow on top of the existing vLLM calibration utilities, covering per-channel statistics collection, optional per-layer alpha grid search, and offline QK / VO / down_proj weight scaling.

Core library (angelslim/compressor/quant/core/vllm_calibrate_utils):
- hooks.py: SmoothAttnHook / SmoothDownProjInputHook for per-channel absmax + EMA on q, k, attn_out and dense down_proj inputs; setup / get / print entry points with TP-aware batched all_gather (groups keys by (size, kv_replicas) to cut O(N) NCCL round-trips down to O(S)); collect_fused_moe_smooth_stats for kernel-injected per-expert stats; optional percentile clipping with stride sub-sampling (set/get_percentile_subsample).
- search.py: SmoothAlphaSearchConfig + SmoothAlphaSearcher grid search over alpha (default and per-tensor-act-first modes) with int8/fp8 x per_tensor/per_token/per_channel/per_group/per_block QDQ; raw activation capture via SmoothAlphaValueHook (dense) and collect_fused_moe_alpha_search_values (MoE kernel injection); rank-0 JSON write to avoid mp executor pickling.
- EP is rejected up front (smooth stats are incompatible with expert parallelism).

vLLM patch (tools/vllm_patch):
- envs.py: register VLLM_MOE_COLLECT_SMOOTH_STATS / VLLM_MOE_COLLECT_ALPHA_SEARCH.
- fused_moe.py: inject collect_fused_moe_smooth_stats and collect_fused_moe_alpha_search_values at the down_proj input point in TritonExperts.
- install.sh: extend post-install checks for the new env vars and kernel injection points.

Tooling (tools/smooth):
- run_vllm_smooth.py: vLLM-driven calibration entrypoint that runs forward over the calibration set, collects smooth stats, and optionally runs the alpha grid search.
- convert_smooth_weights.py: offline weight transform that loads the stats JSON and applies QK / VO / down_proj scaling, with attn / mlp output diff verification and parallel safetensors save.
- README.md: full usage / concept / troubleshooting doc.

Configs & scripts:
- configs/hy3/ptq/hy3_smooth.yaml: shared config for both phases.
- scripts/ptq/run_smooth_for_HY3.sh (one-shot pipeline), run_smooth_calibrate_for_HY3.sh (stats only), run_smooth_convert_for_HY3.sh (offline transform only).
- scripts/ptq/README.md: document the new HY3 smooth scripts.