### PR TITLE
fix(models): fix MoE weight dangling reference and Qwen3-Omni model adapter compatibility

### DIFF
--- a/angelslim/models/llm/qwen.py
+++ b/angelslim/models/llm/qwen.py
@@ -46,7 +46,10 @@ class QwenMoeExpertsWithLinear(Qwen3MoeExperts):
             expert["gate_proj"].weight.data, expert["up_proj"].weight.data = self.gate_up_proj[
                 expert_idx
             ].chunk(2, dim=-2)
-            expert["down_proj"].weight.data = self.down_proj[expert_idx]
+            # Clone weights to avoid dangling references after del self.gate_up_proj
+            expert["gate_proj"].weight.data = expert["gate_proj"].weight.data.clone()
+            expert["up_proj"].weight.data = expert["up_proj"].weight.data.clone()
+            expert["down_proj"].weight.data = self.down_proj[expert_idx].clone()
             setattr(self, f"{expert_idx}", expert)
         del self.gate_up_proj
         del self.down_proj

--- a/angelslim/models/omni/qwen3_omni.py
+++ b/angelslim/models/omni/qwen3_omni.py
@@ -45,6 +45,7 @@ class Qwen_Omni(BaseLLMModel):
             deploy_backend=deploy_backend,
         )
         self.modal_type = "Omni"
+        self.block_name = "thinker.model.layers"
         self.thinker_block_name = "thinker.model.layers"
         self.talker_block_name = "talker.model.layers"
         self.observer_layer_classes = [
@@ -205,8 +206,6 @@ class Qwen_Omni(BaseLLMModel):
         ]
 
     def model_forward(self, dataloader, **kwargs):
-        self.model.use_cache = False
-
         calibrated_cnt = 0
         if (
             "gptq" in self.quant_config.quant_algo


### PR DESCRIPTION
## Summary

Fix critical runtime issues in MoE expert weight handling and Qwen3-Omni model adapter that caused GPTQ quantization failures.

## Changes

### 1. Fix MoE expert weight dangling reference (`angelslim/models/llm/qwen.py`)

After `chunk()` splits `gate_up_proj` into `gate_proj` and `up_proj`, the resulting tensors are views sharing the same underlying storage. When `del self.gate_up_proj` is executed subsequently, the storage is freed, leaving `gate_proj` and `up_proj` as dangling references pointing to invalid memory.

**Fix:** Call `.clone()` on all chunked/sliced weight tensors immediately after assignment to ensure each expert owns an independent copy before the source tensors are deleted.

### 2. Add missing `block_name` attribute to Qwen3-Omni (`angelslim/models/omni/qwen3_omni.py`)

The GPTQ quantization flow requires `self.block_name` to locate transformer blocks. Qwen3-Omni only defined `thinker_block_name` / `talker_block_name` but was missing the base `block_name` attribute, causing `AttributeError` during calibration.

**Fix:** Add `self.block_name = "thinker.model.layers"` to the constructor.

### 3. Remove incompatible `self.model.use_cache = False` (`angelslim/models/omni/qwen3_omni.py`)

The Qwen3-Omni model object does not expose a `use_cache` attribute at the top level (it is configured per-component). Setting it unconditionally raised `AttributeError`.

**Fix:** Remove the incompatible assignment from `model_forward()`.

## Files Changed

- `angelslim/models/llm/qwen.py` — clone expert weights after chunk to prevent dangling references
- `angelslim/models/omni/qwen3_omni.py` — add `block_name` attr; remove invalid `use_cache` assignment