### PR TITLE
Validate token-pruning ratio and unify keep-count resolution

### DIFF
--- a/angelslim/compressor/token_compressor/algorithm/attention_based.py
+++ b/angelslim/compressor/token_compressor/algorithm/attention_based.py
@@ -17,7 +17,10 @@ import math
 import torch
 
 from ..base.context import PruningContext
-from .utils.utils import _extract_and_validate_vision_token_info, resolve_num_tokens_to_keep
+from .utils.utils import (
+    _extract_and_validate_vision_token_info,
+    resolve_num_tokens_to_keep,
+)
 
 
 def special_token_based_attention_pruning(context: PruningContext, **kwargs) -> torch.Tensor:

--- a/angelslim/compressor/token_compressor/algorithm/attention_based.py
+++ b/angelslim/compressor/token_compressor/algorithm/attention_based.py
@@ -17,7 +17,7 @@ import math
 import torch
 
 from ..base.context import PruningContext
-from .utils.utils import _extract_and_validate_vision_token_info
+from .utils.utils import _extract_and_validate_vision_token_info, resolve_num_tokens_to_keep
 
 
 def special_token_based_attention_pruning(context: PruningContext, **kwargs) -> torch.Tensor:
@@ -76,9 +76,7 @@ def special_token_based_attention_pruning(context: PruningContext, **kwargs) -> 
             batch_keep_masks.append(torch.ones_like(ids_single, dtype=torch.bool))
             continue
 
-        num_to_keep = int(round(num_vision_tokens * (1 - ratio)))
-        if ratio < 1.0 and num_to_keep == 0 and num_vision_tokens > 0:
-            num_to_keep = 1
+        num_to_keep = resolve_num_tokens_to_keep(ratio, num_vision_tokens)
 
         if num_to_keep >= num_vision_tokens:
             batch_keep_masks.append(torch.ones_like(ids_single, dtype=torch.bool))

--- a/angelslim/compressor/token_compressor/algorithm/basic.py
+++ b/angelslim/compressor/token_compressor/algorithm/basic.py
@@ -16,7 +16,10 @@
 import torch
 
 from ..base.context import PruningContext
-from .utils.utils import _extract_and_validate_vision_token_info, resolve_num_tokens_to_keep
+from .utils.utils import (
+    _extract_and_validate_vision_token_info,
+    resolve_num_tokens_to_keep,
+)
 
 
 def baseline_pruning(context: PruningContext, **kwargs) -> torch.Tensor:

--- a/angelslim/compressor/token_compressor/algorithm/basic.py
+++ b/angelslim/compressor/token_compressor/algorithm/basic.py
@@ -16,7 +16,7 @@
 import torch
 
 from ..base.context import PruningContext
-from .utils.utils import _extract_and_validate_vision_token_info
+from .utils.utils import _extract_and_validate_vision_token_info, resolve_num_tokens_to_keep
 
 
 def baseline_pruning(context: PruningContext, **kwargs) -> torch.Tensor:
@@ -128,10 +128,7 @@ def random_pruning(context: PruningContext, **kwargs) -> torch.Tensor:
             batch_keep_masks.append(torch.ones_like(input_ids_single, dtype=torch.bool))
             continue
 
-        num_to_keep = int(round(num_vision_tokens * (1 - ratio)))
-        # Retain at least one token if ratio < 1.0
-        if ratio < 1.0 and num_to_keep == 0 and num_vision_tokens > 0:
-            num_to_keep = 1
+        num_to_keep = resolve_num_tokens_to_keep(ratio, num_vision_tokens)
 
         kept_vision_indices = torch.tensor([], dtype=torch.long, device=device)
         if num_to_keep > 0:

--- a/angelslim/compressor/token_compressor/algorithm/dart.py
+++ b/angelslim/compressor/token_compressor/algorithm/dart.py
@@ -23,7 +23,10 @@ import torch
 import torch.nn.functional as F
 
 from ..base.context import PruningContext
-from .utils.utils import _extract_and_validate_vision_token_info, resolve_num_tokens_to_keep
+from .utils.utils import (
+    _extract_and_validate_vision_token_info,
+    resolve_num_tokens_to_keep,
+)
 
 
 def dart_pruning(context: PruningContext, **kwargs) -> torch.Tensor:

--- a/angelslim/compressor/token_compressor/algorithm/dart.py
+++ b/angelslim/compressor/token_compressor/algorithm/dart.py
@@ -23,7 +23,7 @@ import torch
 import torch.nn.functional as F
 
 from ..base.context import PruningContext
-from .utils.utils import _extract_and_validate_vision_token_info
+from .utils.utils import _extract_and_validate_vision_token_info, resolve_num_tokens_to_keep
 
 
 def dart_pruning(context: PruningContext, **kwargs) -> torch.Tensor:
@@ -85,9 +85,7 @@ def dart_pruning(context: PruningContext, **kwargs) -> torch.Tensor:
             batch_keep_masks.append(torch.ones_like(input_ids_single, dtype=torch.bool))
             continue
 
-        num_to_keep = int(round(num_vision_tokens * (1 - ratio)))
-        if ratio < 1.0 and num_to_keep == 0 and num_vision_tokens > 0:
-            num_to_keep = 1
+        num_to_keep = resolve_num_tokens_to_keep(ratio, num_vision_tokens)
         if num_to_keep >= num_vision_tokens:
             batch_keep_masks.append(torch.ones_like(input_ids_single, dtype=torch.bool))
             continue

--- a/angelslim/compressor/token_compressor/algorithm/divprune.py
+++ b/angelslim/compressor/token_compressor/algorithm/divprune.py
@@ -21,7 +21,7 @@ import torch
 import torch.nn.functional as F
 
 from ..base.context import PruningContext
-from .utils.utils import _extract_and_validate_vision_token_info
+from .utils.utils import _extract_and_validate_vision_token_info, resolve_num_tokens_to_keep
 
 
 def divprune(context: PruningContext, **kwargs) -> torch.Tensor:
@@ -67,9 +67,7 @@ def divprune(context: PruningContext, **kwargs) -> torch.Tensor:
             batch_keep_masks.append(torch.ones_like(input_ids_single, dtype=torch.bool))
             continue
 
-        num_to_keep = int(round(num_vision_tokens * (1 - ratio)))
-        if ratio < 1.0 and num_to_keep == 0 and num_vision_tokens > 0:
-            num_to_keep = 1
+        num_to_keep = resolve_num_tokens_to_keep(ratio, num_vision_tokens)
         if num_to_keep >= num_vision_tokens:
             batch_keep_masks.append(torch.ones_like(input_ids_single, dtype=torch.bool))
             continue

--- a/angelslim/compressor/token_compressor/algorithm/divprune.py
+++ b/angelslim/compressor/token_compressor/algorithm/divprune.py
@@ -21,7 +21,10 @@ import torch
 import torch.nn.functional as F
 
 from ..base.context import PruningContext
-from .utils.utils import _extract_and_validate_vision_token_info, resolve_num_tokens_to_keep
+from .utils.utils import (
+    _extract_and_validate_vision_token_info,
+    resolve_num_tokens_to_keep,
+)
 
 
 def divprune(context: PruningContext, **kwargs) -> torch.Tensor:

--- a/angelslim/compressor/token_compressor/algorithm/hiprune.py
+++ b/angelslim/compressor/token_compressor/algorithm/hiprune.py
@@ -25,6 +25,7 @@ from .utils.utils import (
     _extract_and_validate_vision_token_info,
     _recompute_attention_maps_for_all_images,
     identify_model_architecture,
+    resolve_num_tokens_to_keep,
 )
 
 
@@ -119,9 +120,7 @@ def hiprune_pruning(context: PruningContext, **kwargs) -> torch.Tensor:
         deep_score = deep_score.squeeze(0)
         N = shallow_score.shape[0]
 
-        target_k = int(round(N * (1.0 - ratio)))
-        if ratio < 1.0 and target_k == 0 and N > 0:
-            target_k = 1
+        target_k = resolve_num_tokens_to_keep(ratio, N)
 
         if target_k >= N:
             all_kept_indices_global.append(global_idx_map)

--- a/angelslim/compressor/token_compressor/algorithm/idpruner.py
+++ b/angelslim/compressor/token_compressor/algorithm/idpruner.py
@@ -21,7 +21,7 @@ from typing import Callable, Union
 import torch
 
 from ..base.context import PruningContext
-from .utils.utils import _extract_and_validate_vision_token_info
+from .utils.utils import _extract_and_validate_vision_token_info, resolve_num_tokens_to_keep
 from .utils.vision_selector_utils import get_universal_selector_scores
 
 
@@ -105,9 +105,7 @@ def idpruner(context: PruningContext, **kwargs) -> torch.Tensor:
         keep_mask_single = torch.ones_like(ids_single, dtype=torch.bool)
 
         if N > 0:
-            num_to_keep = int(round(N * (1.0 - ratio)))
-            if ratio < 1.0 and num_to_keep == 0:
-                num_to_keep = 1
+            num_to_keep = resolve_num_tokens_to_keep(ratio, N)
 
             if num_to_keep < N:
                 keep_mask_single = torch.zeros_like(ids_single, dtype=torch.bool)

--- a/angelslim/compressor/token_compressor/algorithm/idpruner.py
+++ b/angelslim/compressor/token_compressor/algorithm/idpruner.py
@@ -21,7 +21,10 @@ from typing import Callable, Union
 import torch
 
 from ..base.context import PruningContext
-from .utils.utils import _extract_and_validate_vision_token_info, resolve_num_tokens_to_keep
+from .utils.utils import (
+    _extract_and_validate_vision_token_info,
+    resolve_num_tokens_to_keep,
+)
 from .utils.vision_selector_utils import get_universal_selector_scores
 
 

--- a/angelslim/compressor/token_compressor/algorithm/scope.py
+++ b/angelslim/compressor/token_compressor/algorithm/scope.py
@@ -24,6 +24,7 @@ from ..base.context import PruningContext
 from .utils.utils import (
     _extract_and_validate_vision_token_info,
     _recompute_attention_maps_for_all_images,
+    resolve_num_tokens_to_keep,
 )
 
 
@@ -138,9 +139,7 @@ def scope_pruning(context: PruningContext, **kwargs) -> torch.Tensor:
     cls_attn = torch.cat(scores_list, dim=1).to(device=device, dtype=inputs_embeds.dtype)
 
     # 5. Execute SCOPE core
-    num_to_keep = int(round(N_vision * (1.0 - ratio)))
-    if ratio < 1.0 and num_to_keep == 0 and N_vision > 0:
-        num_to_keep = 1
+    num_to_keep = resolve_num_tokens_to_keep(ratio, N_vision)
 
     if num_to_keep >= N_vision:
         return torch.ones_like(input_ids, dtype=torch.bool)

--- a/angelslim/compressor/token_compressor/algorithm/utils/utils.py
+++ b/angelslim/compressor/token_compressor/algorithm/utils/utils.py
@@ -32,6 +32,47 @@ def _get_config_attr(config: Any, attr_name: str, default: Any = None) -> Any:
     return getattr(config, attr_name, default)
 
 
+def resolve_num_tokens_to_keep(ratio: float, num_vision_tokens: int) -> int:
+    """Validate a pruning ``ratio`` and resolve how many vision tokens to keep.
+
+    Every pruning strategy turns a drop ``ratio`` into an absolute keep count via
+    ``round(num_vision_tokens * (1 - ratio))``. Centralizing it here guarantees a
+    single, consistent contract across all strategies:
+
+    * ``ratio`` must be a real number in the closed interval ``[0.0, 1.0]``.
+      Out-of-range values (e.g. a config typo such as ``ratio: 5``) used to flow
+      straight into the keep count: ``1 - ratio`` went negative, producing a
+      negative ``num_to_keep`` that crashed ``torch.empty`` / ``torch.topk`` or
+      silently corrupted the kept-token set. They now raise a descriptive error.
+    * At least one vision token is retained whenever ``ratio < 1.0`` and there is
+      a vision token available, so a benign rounding-to-zero never drops the whole
+      image. This makes the previously ad-hoc (and, in ``hiprune``, missing)
+      retain-one guard uniform.
+
+    Args:
+        ratio (float): Fraction of vision tokens to drop, in ``[0.0, 1.0]``.
+        num_vision_tokens (int): Number of vision tokens available to prune.
+
+    Returns:
+        int: The number of vision tokens to keep (always ``>= 0``).
+
+    Raises:
+        ValueError: If ``ratio`` is not a real number in ``[0.0, 1.0]``.
+    """
+    if isinstance(ratio, bool) or not isinstance(ratio, (int, float)):
+        raise ValueError(
+            "[TokenCompressor Error] 'ratio' must be a real number in [0.0, 1.0], "
+            f"got {ratio!r}."
+        )
+    if math.isnan(ratio) or not 0.0 <= ratio <= 1.0:
+        raise ValueError(f"[TokenCompressor Error] 'ratio' must be in [0.0, 1.0], got {ratio}.")
+
+    num_to_keep = int(round(num_vision_tokens * (1.0 - ratio)))
+    if ratio < 1.0 and num_to_keep == 0 and num_vision_tokens > 0:
+        num_to_keep = 1
+    return num_to_keep
+
+
 def identify_model_architecture(context: PruningContext) -> str:
     """
     Identifies the model architecture based on the context's model_config.

--- a/angelslim/compressor/token_compressor/algorithm/visionselector.py
+++ b/angelslim/compressor/token_compressor/algorithm/visionselector.py
@@ -20,7 +20,11 @@ Vision Selector Pruning Strategy module.
 import torch
 
 from ..base.context import PruningContext
-from .utils.utils import _extract_and_validate_vision_token_info, get_valid_content_mask
+from .utils.utils import (
+    _extract_and_validate_vision_token_info,
+    get_valid_content_mask,
+    resolve_num_tokens_to_keep,
+)
 from .utils.vision_selector_utils import get_universal_selector_scores
 
 
@@ -89,9 +93,7 @@ def vision_selector_pruning(context: PruningContext, **kwargs) -> torch.Tensor:
         return torch.ones_like(input_ids, dtype=torch.bool)
 
     # Calculate retention target
-    num_to_keep = int(round(num_vision_tokens * (1.0 - pruning_ratio)))
-    if pruning_ratio < 1.0 and num_to_keep == 0:
-        num_to_keep = 1
+    num_to_keep = resolve_num_tokens_to_keep(pruning_ratio, num_vision_tokens)
 
     # If budget exceeds current token count, retain everything
     if num_to_keep >= num_vision_tokens:

--- a/configs/qwen2_5_vl/pruning/vision_selector_r0.9.yaml
+++ b/configs/qwen2_5_vl/pruning/vision_selector_r0.9.yaml
@@ -16,7 +16,7 @@ compressor:
     global:
       strategy: "vision_selector"
       params:
-        ratio: 9
+        ratio: 0.9
       model_related_params:
         selector_path:
           "7b": "AngelSlim/Qwen2.5-VL-7B-Instruct-Selector"

--- a/tests/test_token_pruning_ratio.py
+++ b/tests/test_token_pruning_ratio.py
@@ -1,0 +1,161 @@
+# Copyright 2025 Tencent Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``resolve_num_tokens_to_keep`` ratio validation.
+
+These tests are CPU-only and require neither a GPU nor model weights: the
+``torch`` imports and the ``PruningContext`` dependency pulled in by
+``algorithm/utils/utils.py`` are stubbed so that the pure keep-count resolution
+logic shared by every pruning strategy can be exercised in isolation.
+
+Regression target: every strategy converts a drop ``ratio`` into an absolute
+keep count via ``round(num_vision_tokens * (1 - ratio))``. An out-of-range
+``ratio`` (e.g. a config typo such as ``ratio: 5``) used to flow straight into
+that expression, yielding a negative ``num_to_keep`` that crashed
+``torch.empty`` / ``torch.topk`` or silently corrupted the kept-token set.
+"""
+
+import importlib.util
+import math
+import os
+import sys
+import types
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_UTILS_PATH = os.path.join(
+    _REPO_ROOT,
+    "angelslim",
+    "compressor",
+    "token_compressor",
+    "algorithm",
+    "utils",
+    "utils.py",
+)
+_MODULE_NAME = "angelslim.compressor.token_compressor.algorithm.utils.utils"
+
+
+def _install_stubs():
+    """Register lightweight stand-ins so ``utils.py`` imports cleanly."""
+
+    def _module(name):
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+        return mod
+
+    class _AnyAttrModule(types.ModuleType):
+        """A module whose every attribute access yields a harmless placeholder.
+
+        ``utils.py`` references ``torch.Tensor`` (and friends) inside function type
+        annotations, which are evaluated at import time; returning ``object`` for any
+        attribute lets the module load without the real ``torch`` installed.
+        """
+
+        def __getattr__(self, _name):
+            return object
+
+    # torch + torch.nn.functional (only referenced in annotations, never called here)
+    if "torch" not in sys.modules:
+        torch = _AnyAttrModule("torch")
+        sys.modules["torch"] = torch
+        torch_nn = _AnyAttrModule("torch.nn")
+        sys.modules["torch.nn"] = torch_nn
+        torch_functional = _AnyAttrModule("torch.nn.functional")
+        sys.modules["torch.nn.functional"] = torch_functional
+        torch_nn.functional = torch_functional
+        torch.nn = torch_nn
+
+    # Parent packages of the target module, marked as packages.
+    for pkg in (
+        "angelslim",
+        "angelslim.compressor",
+        "angelslim.compressor.token_compressor",
+        "angelslim.compressor.token_compressor.base",
+        "angelslim.compressor.token_compressor.algorithm",
+        "angelslim.compressor.token_compressor.algorithm.utils",
+    ):
+        if pkg not in sys.modules:
+            mod = _module(pkg)
+            mod.__path__ = []  # mark as package
+
+    # angelslim...base.context.PruningContext (resolved via the relative import)
+    ctx_name = "angelslim.compressor.token_compressor.base.context"
+    if ctx_name not in sys.modules:
+        ctx = _module(ctx_name)
+        ctx.PruningContext = type("PruningContext", (), {})
+
+
+def _load_utils_module():
+    _install_stubs()
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _UTILS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def resolve():
+    return _load_utils_module().resolve_num_tokens_to_keep
+
+
+@pytest.mark.parametrize(
+    "ratio,num_tokens,expected",
+    [
+        (0.0, 100, 100),  # drop nothing -> keep all
+        (0.25, 100, 75),
+        (0.5, 100, 50),
+        (0.9, 100, 10),
+        (1.0, 100, 0),  # drop everything -> keep none
+        (0.0, 0, 0),  # no vision tokens at all
+    ],
+)
+def test_in_range_ratio_resolves_expected_keep_count(resolve, ratio, num_tokens, expected):
+    assert resolve(ratio, num_tokens) == expected
+
+
+def test_rounding_to_zero_retains_one_token(resolve):
+    """A benign rounding-to-zero must never drop the whole image (ratio < 1.0)."""
+    # round(3 * (1 - 0.99)) == round(0.03) == 0 -> clamped up to 1
+    assert resolve(0.99, 3) == 1
+
+
+def test_ratio_one_keeps_zero_not_one(resolve):
+    """ratio == 1.0 is an explicit "keep none"; the retain-one guard must not fire."""
+    assert resolve(1.0, 3) == 0
+
+
+@pytest.mark.parametrize("ratio", [1.0001, 5, 100.0])
+def test_ratio_above_one_raises(resolve, ratio):
+    """ratio > 1.0 previously produced a negative keep count (torch crash)."""
+    with pytest.raises(ValueError, match=r"\[TokenCompressor Error\] 'ratio'"):
+        resolve(ratio, 100)
+
+
+@pytest.mark.parametrize("ratio", [-0.1, -1, -100.0])
+def test_negative_ratio_raises(resolve, ratio):
+    with pytest.raises(ValueError, match=r"\[TokenCompressor Error\] 'ratio'"):
+        resolve(ratio, 100)
+
+
+def test_nan_ratio_raises(resolve):
+    with pytest.raises(ValueError, match=r"\[TokenCompressor Error\] 'ratio'"):
+        resolve(math.nan, 100)
+
+
+@pytest.mark.parametrize("ratio", [None, "0.5", True])
+def test_non_numeric_ratio_raises(resolve, ratio):
+    """``bool`` is rejected explicitly so ``True``/``False`` never act as 1/0."""
+    with pytest.raises(ValueError, match=r"\[TokenCompressor Error\] 'ratio'"):
+        resolve(ratio, 100)


### PR DESCRIPTION
## Summary

Every token-compressor pruning strategy turns a drop `ratio` into an absolute
keep count via `int(round(num_vision_tokens * (1 - ratio)))`. Today each strategy
does this inline, with its own ad-hoc "retain at least one token" guard — and
none of them validate that `ratio` actually lies in `[0, 1]`.

That gap is a real defect:

- **`ratio > 1`** makes `1 - ratio` negative, so `num_to_keep` goes negative and
  flows straight into `torch.empty(num_to_keep, ...)` (divprune) /
  `torch.topk(..., k=min(num_to_keep, n))` (attention_based, vispruner) / the
  pivot math in dart — which raises an opaque CUDA/CPU error deep inside torch,
  far from the actual cause.
- **`ratio < 0`** over-counts and silently changes the kept-token set.
- The retain-one guard is inconsistent: `hiprune` doesn't apply it at all, so a
  benign rounding-to-zero there drops the entire image.

This isn't hypothetical — the shipped config
[`configs/qwen2_5_vl/pruning/vision_selector_r0.9.yaml`](https://github.com/Tencent/AngelSlim/blob/main/configs/qwen2_5_vl/pruning/vision_selector_r0.9.yaml)
carries `ratio: 9` even though the filename says `r0.9`, so running it today
crashes instead of pruning to 10%.

## Changes

- Add a single shared helper `resolve_num_tokens_to_keep(ratio, num_vision_tokens)`
  in `algorithm/utils/utils.py` that:
  - rejects a non-numeric / `bool` / `NaN` / out-of-`[0,1]` ratio with a clear
    `[TokenCompressor Error] 'ratio' must be in [0.0, 1.0], got <x>` message;
  - computes `round(num_vision_tokens * (1 - ratio))`;
  - applies one uniform "retain at least one token when `ratio < 1.0`" rule.
- Route all eight strategies (`basic`, `attention_based`, `dart`, `divprune`,
  `hiprune`, `idpruner`, `scope`, `vision_selector`) through the helper, removing
  the duplicated inline blocks. Behaviour is unchanged for valid ratios; `hiprune`
  gains the retain-one guard for consistency.
- Fix the `ratio: 9` → `0.9` typo in the vision_selector config so the example
  actually runs.
- Add a CPU-only regression test (`tests/test_token_pruning_ratio.py`) that pins
  the contract — it stubs the `torch` import so it needs neither a GPU nor model
  weights.

## Testing

```
$ python -m pytest tests/test_token_pruning_ratio.py -q
18 passed
```

Formatting matches the repo pre-commit hooks: `black --line-length=99`,
`isort --profile=black`, and `flake8 (E203,E704,W503,W504 ignored)` are all clean.

## Notes

Out-of-range ratios were never a working path (they crashed or corrupted), so
raising a descriptive `ValueError` instead is strictly safer and not a behavioural
regression for any valid configuration.
