### PR TITLE
Keep all turns and fix system prompt in ShareGPT conversations parsing

### DIFF
--- a/angelslim/data/text_dataset.py
+++ b/angelslim/data/text_dataset.py
@@ -261,13 +261,25 @@ class TextDataset(BaseDataset):
             ):
                 messages = [{"role": "system", "content": data["system_prompt"]}] + messages
         elif "conversations" in data:
-            share_gpt_data = data["conversations"]
-            messages = [
-                {"role": "user", "content": share_gpt_data[0]["value"]},
-                {"role": "assistant", "content": share_gpt_data[1]["value"]},
-            ]
-            if "system" in data and data["system"]:
-                messages = [{"role": "system", "content": data["system_prompt"]}] + messages
+            # ShareGPT-style record: a list of multi-turn entries keyed by
+            # ``from``/``value``. Keep every turn and carry its role through so
+            # the normalization below maps each one. The previous code read
+            # only the first two turns and assumed a fixed user/assistant
+            # ordering, which silently dropped longer conversations and
+            # mislabeled system-led ones.
+            messages = []
+            for turn in data["conversations"]:
+                content = turn.get("content", turn.get("value"))
+                if content is None:
+                    # Skip malformed turns that carry no text payload.
+                    continue
+                role = turn.get("role", turn.get("from", ""))
+                messages.append({"role": role, "content": content})
+            # ShareGPT keeps an optional system prompt alongside the turns
+            # rather than inside ``conversations``.
+            system_prompt = data.get("system") or data.get("system_prompt")
+            if system_prompt and (not messages or messages[0]["role"] != "system"):
+                messages = [{"role": "system", "content": system_prompt}] + messages
         else:
             messages = [
                 {"role": "user", "content": data["input"]},
@@ -282,7 +294,7 @@ class TextDataset(BaseDataset):
                 item["role"] = item["from"]
             if "content" not in item and "value" in item:
                 item["content"] = item["value"]
-            role = item["role"]
+            role = item.get("role") or ""
             if "human" in role:
                 item["role"] = "user"
             elif "gpt" in role:

--- a/tests/test_text_dataset_messages.py
+++ b/tests/test_text_dataset_messages.py
@@ -1,0 +1,170 @@
+# Copyright 2025 Tencent Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``TextDataset._prepare_messages``.
+
+These tests are CPU-only and require neither a GPU, model weights, nor the
+heavy ``torch``/``transformers``/``datasets``/``pyarrow`` stack: those imports
+pulled in by ``angelslim.data.text_dataset`` are stubbed so the pure-dict
+message-preparation logic can be exercised in isolation. ``_prepare_messages``
+does not touch ``self``, so it is invoked on an uninitialized instance.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_TEXT_DATASET_PATH = os.path.join(_REPO_ROOT, "angelslim", "data", "text_dataset.py")
+
+
+def _install_stubs():
+    """Register lightweight stand-ins so ``text_dataset.py`` imports cleanly."""
+
+    def _module(name):
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+        return mod
+
+    if "torch" not in sys.modules:
+        _module("torch")
+    if "pyarrow" not in sys.modules:
+        pyarrow = _module("pyarrow")
+        pyarrow.parquet = _module("pyarrow.parquet")
+    if "datasets" not in sys.modules:
+        datasets = _module("datasets")
+        datasets.load_dataset = lambda *a, **k: None
+    if "transformers" not in sys.modules:
+        transformers = _module("transformers")
+        transformers.ProcessorMixin = object
+
+    # angelslim.data.base_dataset.BaseDataset (the only intra-package import)
+    for pkg in ("angelslim", "angelslim.data"):
+        if pkg not in sys.modules:
+            mod = _module(pkg)
+            mod.__path__ = []  # mark as package
+    name = "angelslim.data.base_dataset"
+    if name not in sys.modules:
+        mod = _module(name)
+        mod.BaseDataset = type("BaseDataset", (), {})
+
+
+def _load_text_dataset_cls():
+    _install_stubs()
+    spec = importlib.util.spec_from_file_location(
+        "angelslim.data.text_dataset", _TEXT_DATASET_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.TextDataset
+
+
+@pytest.fixture(scope="module")
+def prepare():
+    cls = _load_text_dataset_cls()
+    instance = cls.__new__(cls)  # skip __init__ (which loads data / a processor)
+    return instance._prepare_messages
+
+
+def test_conversations_with_system_field_does_not_crash(prepare):
+    """A ShareGPT record carrying a ``system`` field must not raise.
+
+    Regression: the branch guarded on ``data["system"]`` but read
+    ``data["system_prompt"]``, raising ``KeyError: 'system_prompt'``.
+    """
+    data = {
+        "system": "You are a helpful assistant.",
+        "conversations": [
+            {"from": "human", "value": "Hi"},
+            {"from": "gpt", "value": "Hello!"},
+        ],
+    }
+    messages = prepare(data)
+    assert messages[0] == {"role": "system", "content": "You are a helpful assistant."}
+    assert messages[1]["role"] == "user"
+    assert messages[2]["role"] == "assistant"
+
+
+def test_conversations_keeps_all_turns(prepare):
+    """Every turn of a multi-turn conversation is preserved and role-mapped.
+
+    Regression: only the first two turns were kept (positional user/assistant),
+    dropping the rest of a multi-turn ShareGPT record.
+    """
+    data = {
+        "conversations": [
+            {"from": "human", "value": "q1"},
+            {"from": "gpt", "value": "a1"},
+            {"from": "human", "value": "q2"},
+            {"from": "gpt", "value": "a2"},
+        ]
+    }
+    messages = prepare(data)
+    assert [m["role"] for m in messages] == ["user", "assistant", "user", "assistant"]
+    assert [m["content"] for m in messages] == ["q1", "a1", "q2", "a2"]
+
+
+def test_conversations_system_turn_is_not_duplicated(prepare):
+    """A leading system turn must not be doubled by the system-field prepend."""
+    data = {
+        "system": "S",
+        "conversations": [
+            {"from": "system", "value": "S"},
+            {"from": "human", "value": "q"},
+            {"from": "gpt", "value": "a"},
+        ],
+    }
+    messages = prepare(data)
+    assert [m["role"] for m in messages] == ["system", "user", "assistant"]
+
+
+def test_conversations_skips_malformed_turn(prepare):
+    """Turns without a text payload are skipped instead of crashing later."""
+    data = {
+        "conversations": [
+            {"from": "human", "value": "q"},
+            {"from": "gpt"},  # no value/content
+            {"from": "gpt", "value": "a"},
+        ]
+    }
+    messages = prepare(data)
+    assert [m["content"] for m in messages] == ["q", "a"]
+
+
+def test_messages_branch_unchanged(prepare):
+    """The ``messages`` branch keeps its existing behavior (no regression)."""
+    data = {
+        "system_prompt": "sys",
+        "messages": [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "a"},
+        ],
+    }
+    messages = prepare(data)
+    assert messages[0] == {"role": "system", "content": "sys"}
+    assert messages[1]["role"] == "user"
+    assert messages[2]["role"] == "assistant"
+
+
+def test_input_output_branch_unchanged(prepare):
+    """The plain input/output branch keeps its existing behavior."""
+    data = {"input": "q", "output": "a"}
+    messages = prepare(data)
+    assert messages == [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "a"},
+    ]


### PR DESCRIPTION
## What

Fix ShareGPT `conversations` handling in `TextDataset._prepare_messages`
(`angelslim/data/text_dataset.py`). The branch had two correctness bugs:

1. **`KeyError: 'system_prompt'`** — it guarded on `data["system"]` but then
   read `data["system_prompt"]`:

   ```python
   if "system" in data and data["system"]:
       messages = [{"role": "system", "content": data["system_prompt"]}] + messages
   ```

   Any ShareGPT record that carries a `system` field crashes during data
   loading. (The sibling `messages` and `input`/`output` branches correctly
   guard *and* read `system_prompt`; only this branch was inconsistent.)

2. **Multi-turn conversations were truncated to the first two turns** and roles
   were assigned positionally:

   ```python
   share_gpt_data = data["conversations"]
   messages = [
       {"role": "user", "content": share_gpt_data[0]["value"]},
       {"role": "assistant", "content": share_gpt_data[1]["value"]},
   ]
   ```

   A standard multi-turn ShareGPT record (`[{"from": "human", ...}, {"from":
   "gpt", ...}, {"from": "human", ...}, ...]`) lost every turn after the second,
   and the actual `from` of each turn was ignored. This defeats the downstream
   loop, which already scans for the *last* assistant turn and treats everything
   before it as prompt context — i.e. the pipeline is built for multi-turn data.

## How

- Iterate over **all** turns, carrying each turn's role/content through the
  existing role-normalization loop (which already maps `from`→`role`,
  `value`→`content`, and `human`→`user` / `gpt`→`assistant`).
- Prepend the optional dataset-level system prompt (`data["system"]`, with
  `data["system_prompt"]` accepted as a fallback), **deduplicated** against a
  conversation that already begins with a `system` turn so it is not doubled.
- Skip turns that carry no text payload, and harden the normalization loop so a
  turn missing a role no longer raises. The `messages` and `input`/`output`
  branches are left behavior-identical (the `.get` is a no-op for them).

## Tests

`tests/test_text_dataset_messages.py` — CPU-only, no GPU / model weights / heavy
stack (the `torch`/`transformers`/`datasets`/`pyarrow` imports are stubbed;
`_prepare_messages` is pure-dict). Covers: system-field no-crash regression,
all-turns-preserved, leading-system-turn dedup, malformed-turn skip, and the
unchanged `messages` / `input-output` branches. The four `conversations` cases
fail on `main` and pass here; the two non-`conversations` cases pass on both.

## Note on reuse

`angelslim/compressor/speculative/train/data/data_utils.py` already has a
`convert_sharegpt_data` helper with the same `human`→`user` / `gpt`→`assistant`
mapping. It is intentionally **not** reused here because it lives in the
`speculative.train.data` subpackage and pulls `transformers.image_utils` and
training-only deps at import — importing it into the core data loader would add
a heavier cross-package dependency than the few lines here. It also indexes
`role_mapping[message["from"]]` directly, which raises on a `system` turn,
whereas the normalization in `text_dataset.py` handles system turns.

**Reviewer check:** does keeping all turns + prepending the system prompt match
the intended ShareGPT calibration format, or should the loader continue to
support only single-turn `conversations`? The downstream `_load_data` loop
(scanning for the last assistant turn) suggests multi-turn is intended.
