### PR TITLE
fix(models): SeedOss crash — call find_layers as a function, not self.find_layers

### DIFF
--- a/angelslim/models/llm/seed_oss.py
+++ b/angelslim/models/llm/seed_oss.py
@@ -15,6 +15,7 @@
 import re
 
 from ...compressor.quant.core import PTQSaveVllmHF
+from ...utils.utils import find_layers
 from ..base_model import BaseLLMModel
 from ..model_factory import SlimModelFactory
 
@@ -43,7 +44,7 @@ class SeedOss(BaseLLMModel):
             "down_proj",
         ]
         observer_layers_dict = {}
-        layers_dict = self.find_layers(self.model, layers=self.observer_layer_classes)
+        layers_dict = find_layers(self.model, layers=self.observer_layer_classes)
 
         ignore_layers = self.skip_layer_names()
         for name, module in layers_dict.items():


### PR DESCRIPTION
## Problem

Any Seed-OSS quantization run crashes at `init_ptq()` / observer setup with:

```
AttributeError: 'SeedOss' object has no attribute 'find_layers'
```

## Root cause

`SeedOss.get_observer_layers()` calls `self.find_layers(...)`, but `find_layers` is a **module-level function** in `angelslim/utils/utils.py` — there is no `find_layers` method on `BaseLLMModel` (or anywhere in the package). Every other LLM adapter imports and calls it as a bare function (e.g. `qwen.py`):

```python
from ...utils.utils import find_layers, find_parent_layer_and_sub_name, print_info
...
layers_dict = find_layers(self.model, layers=self.observer_layer_classes)
```

`seed_oss.py` is the only adapter that neither imports `find_layers` nor prefixes it with `self.`, so the lookup hits `BaseLLMModel.__getattr__` and raises `AttributeError`.

## Fix

Import `find_layers` and call it directly, matching the sibling adapters:

```diff
+from ...utils.utils import find_layers
 from ..base_model import BaseLLMModel
 ...
-layers_dict = self.find_layers(self.model, layers=self.observer_layer_classes)
+layers_dict = find_layers(self.model, layers=self.observer_layer_classes)
```

## Verification
- `python3 -m py_compile angelslim/models/llm/seed_oss.py` passes.
- `grep -rn "def find_layers"` shows it is only a module-level function (`angelslim/utils/utils.py:84`); no class defines it as a method.
- `grep -n "find_layers" angelslim/models/base_model.py` returns nothing, confirming `BaseLLMModel` has no such attribute.
