### PR TITLE
fix(stem): IndexError on models with more than 38 layers (Qwen3-32B/235B, DeepSeek-R1)

### DIFF
--- a/angelslim/compressor/sparsity/stem/backends/torch_impl.py
+++ b/angelslim/compressor/sparsity/stem/backends/torch_impl.py
@@ -46,7 +46,13 @@ except ImportError:
 # ---------------------------------------------------------------------------
 
 # Default per-layer keep-ratio: first 2 layers keep 100%, remaining layers 20%.
-_DEFAULT_LAYER_KEEP_RATIOS: list[float] = [1.0, 1.0] + [0.2] * 36
+# Exposed as a function of ``layer_idx`` (rather than a fixed-length list) so it
+# generalizes to models with more than 38 transformer layers — e.g. Qwen3-32B
+# has 64 layers and Qwen3-235B-A22B has 94 layers. A length-38 list indexed by
+# ``layer_idx`` raised ``IndexError`` for those models on the very first prefill.
+def _default_layer_keep_ratio(layer_idx: int) -> float:
+    """Return the default token keep-ratio for the given transformer layer."""
+    return 1.0 if layer_idx < 2 else 0.2
 
 # Short-sequence thresholds — below these lengths the sparsity schedule is
 # relaxed to avoid losing too much context.
@@ -89,7 +95,7 @@ def generate_exact_k_schedule(
     torch.Tensor
         Budget schedule — ``(num_blocks,)`` or ``(num_heads, num_blocks)``.
     """
-    keep_ratio = _DEFAULT_LAYER_KEEP_RATIOS[layer_idx]
+    keep_ratio = _default_layer_keep_ratio(layer_idx)
     per_head_ratios = [keep_ratio] * (num_heads or 1)
 
     def _build_single_schedule(k_val: int, n: int) -> torch.Tensor:


### PR DESCRIPTION
## Problem

Running Stem sparse-attention prefill on a model with **more than 38 transformer layers** crashes immediately:

```
IndexError: list index out of range
```

This affects flagship models AngelSlim explicitly supports, e.g. **Qwen3-32B** (64 layers) and **Qwen3-235B-A22B** (94 layers), as well as DeepSeek-R1/V3 (61 layers).

## Root cause

`generate_exact_k_schedule()` reads the per-layer keep ratio from a fixed-length list:

```python
# angelslim/compressor/sparsity/stem/backends/torch_impl.py:49
_DEFAULT_LAYER_KEEP_RATIOS: list[float] = [1.0, 1.0] + [0.2] * 36   # length 38
...
keep_ratio = _DEFAULT_LAYER_KEEP_RATIOS[layer_idx]
```

`layer_idx` is assigned to **every** transformer layer (`stem/patch.py` sets `self.self_attn.layer_idx = i` for all layers), so for any model with > 38 layers the lookup overflows the list.

## Fix

Express the default keep-ratio as a function of `layer_idx` instead of a length-38 list. It reproduces the exact previous values for layers `0..37` (1.0 for the first two layers, 0.2 thereafter) and extends the same rule to deeper layers:

```diff
-def _DEFAULT_LAYER_KEEP_RATIOS ... = [1.0, 1.0] + [0.2] * 36
+def _default_layer_keep_ratio(layer_idx: int) -> float:
+    return 1.0 if layer_idx < 2 else 0.2
...
-    keep_ratio = _DEFAULT_LAYER_KEEP_RATIOS[layer_idx]
+    keep_ratio = _default_layer_keep_ratio(layer_idx)
```

## Verification
- `python3 -m py_compile` passes.
- Value-equivalence check:
  ```python
  old = [1.0, 1.0] + [0.2] * 36
  assert all(_default_layer_keep_ratio(i) == old[i] for i in range(38))   # identical 0..37
  for i in range(38, 94): assert _default_layer_keep_ratio(i) == 0.2      # no longer raises
  ```
- Confirmed `_DEFAULT_LAYER_KEEP_RATIOS` had no other references (only the definition + this call site).
