### PR TITLE
fix(quant): migrate int8/fp8/awq/lepto_fp8 to new Catcher API (regression from #318)

### DIFF
--- a/angelslim/compressor/quant/modules/awq/awq.py
+++ b/angelslim/compressor/quant/modules/awq/awq.py
@@ -128,16 +128,22 @@ class AWQ:
             device=dev,
             dtype=self.dtype,
         )
-        cache = {"i": 0}
         layers[0] = layers[0].to(dev)
         pre_transformer_modules_dict = self.model.get_pre_transformer_modules()
         for _, module in pre_transformer_modules_dict.items():
             module.to(dev)
-        layers[0] = Catcher(layers[0], self.inps, cache)
+        layers[0] = Catcher(layers[0], max_seq_length=self.seq_length)
         self.model.model_forward(dataloader)
         for _, module in pre_transformer_modules_dict.items():
             module.cpu()
-        layer_kwargs = layers[0].layer_kwargs
+        # Catcher stores per-sample captures; rebuild the fixed-shape inps
+        # tensor and a single layer_kwargs dict to match the previous API.
+        captured_inputs = layers[0].captured_inputs
+        captured_kwargs = layers[0].captured_kwargs
+        for idx in range(min(len(captured_inputs), self.inps.shape[0])):
+            inp = captured_inputs[idx]
+            self.inps[idx, : inp.shape[1], :].copy_(inp[0])
+        layer_kwargs = captured_kwargs[0] if captured_kwargs else {}
         if self.model.model.config.model_type == "hunyuan_vl":
             layer_kwargs["position_embeddings"] = None
         for k, v in layer_kwargs.items():
@@ -148,7 +154,7 @@ class AWQ:
                     for item in v
                 )
 
-        print_info("cache['i']:{}".format(cache["i"]))
+        print_info("captured samples: {}".format(len(captured_inputs)))
         print_info(len(layers))
         layers[0] = layers[0].module
         print_info(self.inps.shape)

--- a/angelslim/compressor/quant/modules/fp8/fp8.py
+++ b/angelslim/compressor/quant/modules/fp8/fp8.py
@@ -82,12 +82,18 @@ class FP8:
             device=dev,
             dtype=self.dtype,
         )
-        cache = {"i": 0}
         layers[0] = layers[0].to(dev)
         self.model.model.model.embed_tokens = self.model.model.model.embed_tokens.to(dev)
-        layers[0] = Catcher(layers[0], self.inps, cache)
+        layers[0] = Catcher(layers[0], max_seq_length=self.seq_length)
         self.model.model_forward(dataloader)
-        layer_kwargs = layers[0].layer_kwargs
+        # Catcher stores per-sample captures; rebuild the fixed-shape inps
+        # tensor and a single layer_kwargs dict to match the previous API.
+        captured_inputs = layers[0].captured_inputs
+        captured_kwargs = layers[0].captured_kwargs
+        for idx in range(min(len(captured_inputs), self.inps.shape[0])):
+            inp = captured_inputs[idx]
+            self.inps[idx, : inp.shape[1], :].copy_(inp[0])
+        layer_kwargs = captured_kwargs[0] if captured_kwargs else {}
         dev = get_best_device()
         for k, v in layer_kwargs.items():
             # position embeddings
@@ -99,7 +105,7 @@ class FP8:
             if isinstance(v, torch.Tensor):
                 layer_kwargs[k] = v.to(dev)
 
-        print_info("cache['i']:{}".format(cache["i"]))
+        print_info("captured samples: {}".format(len(captured_inputs)))
         print_info(len(layers))
         layers[0] = layers[0].module
         print_info(self.inps.shape)

--- a/angelslim/compressor/quant/modules/fp8/lepto_fp8.py
+++ b/angelslim/compressor/quant/modules/fp8/lepto_fp8.py
@@ -80,14 +80,20 @@ class LeptoFP8:
             device=dev,
             dtype=self.dtype,
         )
-        cache = {"i": 0}
         layers[0] = layers[0].to(dev)
         self.quant_model.model.model.embed_tokens = self.quant_model.model.model.embed_tokens.to(
             dev
         )
-        layers[0] = Catcher(layers[0], self.inps, cache)
+        layers[0] = Catcher(layers[0], max_seq_length=self.seq_length)
         self.quant_model.model_forward(dataloader)
-        layer_kwargs = layers[0].layer_kwargs
+        # Catcher stores per-sample captures; rebuild the fixed-shape inps
+        # tensor and a single layer_kwargs dict to match the previous API.
+        captured_inputs = layers[0].captured_inputs
+        captured_kwargs = layers[0].captured_kwargs
+        for idx in range(min(len(captured_inputs), self.inps.shape[0])):
+            inp = captured_inputs[idx]
+            self.inps[idx, : inp.shape[1], :].copy_(inp[0])
+        layer_kwargs = captured_kwargs[0] if captured_kwargs else {}
         for k, v in layer_kwargs.items():
             # position embeddings
             if isinstance(v, tuple):
@@ -96,7 +102,7 @@ class LeptoFP8:
                     for item in v
                 )
 
-        print_info("cache['i']:{}".format(cache["i"]))
+        print_info("captured samples: {}".format(len(captured_inputs)))
         print_info(len(layers))
         layers[0] = layers[0].module
         print_info(self.inps.shape)

--- a/angelslim/compressor/quant/modules/int8/int8.py
+++ b/angelslim/compressor/quant/modules/int8/int8.py
@@ -81,12 +81,18 @@ class INT8:
             device=dev,
             dtype=self.dtype,
         )
-        cache = {"i": 0}
         layers[0] = layers[0].to(dev)
         self.model.model.model.embed_tokens = self.model.model.model.embed_tokens.to(dev)
-        layers[0] = Catcher(layers[0], self.inps, cache)
+        layers[0] = Catcher(layers[0], max_seq_length=self.seq_length)
         self.model.model_forward(dataloader)
-        layer_kwargs = layers[0].layer_kwargs
+        # Catcher stores per-sample captures; rebuild the fixed-shape inps
+        # tensor and a single layer_kwargs dict to match the previous API.
+        captured_inputs = layers[0].captured_inputs
+        captured_kwargs = layers[0].captured_kwargs
+        for idx in range(min(len(captured_inputs), self.inps.shape[0])):
+            inp = captured_inputs[idx]
+            self.inps[idx, : inp.shape[1], :].copy_(inp[0])
+        layer_kwargs = captured_kwargs[0] if captured_kwargs else {}
         dev = get_best_device()
         for k, v in layer_kwargs.items():
             # position embeddings
@@ -96,7 +102,7 @@ class INT8:
                     for item in v
                 )
 
-        print_info("cache['i']:{}".format(cache["i"]))
+        print_info("captured samples: {}".format(len(captured_inputs)))
         print_info(len(layers))
         layers[0] = layers[0].module
         print_info(self.inps.shape)


### PR DESCRIPTION
## Problem

`INT8`, `FP8`, `AWQ`, and `LeptoFP8` quantization all crash at the very start of calibration:

```
TypeError: Catcher.__init__() takes 2 positional arguments but 4 were given
```

(followed by `AttributeError: ... has no attribute 'layer_kwargs'` once the constructor were bypassed.)

Four core PTQ algorithms are effectively unusable.

## Root cause

PR #318 (`86479db`, *"fix(gptq): fix Hessian computation, variable-length sequence support…"*) refactored the `Catcher` class to a new API and migrated `gptq.py` to it — but **four sibling modules were left calling the removed API**:

```python
# int8.py, fp8.py, awq.py, lepto_fp8.py  (OLD API — no longer exists)
layers[0] = Catcher(layers[0], self.inps, cache)
layer_kwargs = layers[0].layer_kwargs
```

The current `Catcher` (`angelslim/compressor/quant/modules/catcher.py`) has signature:

```python
def __init__(self, module, max_seq_length=None): ...
```

and exposes `.captured_inputs` / `.captured_kwargs` (per-sample lists) — there is no 3rd positional arg and no `.layer_kwargs` attribute. Only `gptq.py` was updated to the new API in #318:

```python
layers[0] = Catcher(layers[0], max_seq_length=self.seq_length)
...
inps = layers[0].captured_inputs
layer_kwargs_list = layers[0].captured_kwargs
```

## Fix

Migrate the four callers the same way `gptq.py` already does: construct with `max_seq_length=self.seq_length`, then rebuild the fixed-shape `self.inps` tensor from `captured_inputs` and take `layer_kwargs` from `captured_kwargs[0]` (matching the previous single-shared-dict usage). The existing per-layer forward loops (`self.inps[i:i+bs]` / `self.inps[j:j+1]` with `**layer_kwargs`) are unchanged.

`awq.py`'s `hunyuan_vl` override (`layer_kwargs["position_embeddings"] = None`) still works since it operates on the reconstructed dict.

## Verification
- `python3 -m py_compile` passes for all four files; no stale `self.inps, cache` / `.layer_kwargs` / `cache["i"]` references remain.
- End-to-end simulation of capture → reconstruct → layer forward (using the real `Catcher`):
  - per-sample capture produces `captured_inputs` (`[1, seq, hidden]`) and `captured_kwargs`;
  - reconstruction rebuilds the `[N, seq_length, hidden]` tensor and handles variable `seq_len` via padding;
  - `layer_kwargs = captured_kwargs[0]` is forward-safe (`hidden_states` / `past_key_values` are filtered by `Catcher._FILTER_KWARGS`), and `layer(hidden_states=..., **layer_kwargs)` succeeds for every sample.
- The reachability of these four algorithms is confirmed: they are exported from `angelslim/compressor/quant/modules/__init__.py` and imported by `ptq.py`.

Note: I validated the capture/reconstruction logic in isolation (no GPU); a final on-hardware smoke run of each algorithm by a maintainer would be welcome.
